### PR TITLE
v2.9.0 — auditability: docs-site parity, Scorecard trend, CII answers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Kayforkind"
   }, "metadata": {
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.8.0"
+  "version": "2.9.0"
  },
  "plugins": [
   {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "displayName": "reimagine-it",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
   "author": {
     "name": "Kayforkind"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.github/scorecard-baseline.json
+++ b/.github/scorecard-baseline.json
@@ -1,0 +1,6 @@
+{
+  "aggregateScore": 6.7,
+  "updated": "2026-09-05",
+  "source": "https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it",
+  "note": "Baseline for the weekly scorecard-report.yml trend check. Bump via PR when the live score improves; a drop below this opens a regression issue automatically."
+}

--- a/.github/workflows/content-signals.yml
+++ b/.github/workflows/content-signals.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: the signals step diffs against the base branch,
+          # which a default shallow checkout cannot see.
+          fetch-depth: 0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -60,6 +64,12 @@ jobs:
       - name: Post or update the PR comment
         if: steps.signals.outcome == 'success'
         run: |
+          # The signals step exits early (without writing comment.md) when
+          # no HTML actually changed — a clean no-op, not a failure.
+          if [ ! -f comment.md ]; then
+            echo "no HTML changed — nothing to comment"
+            exit 0
+          fi
           MARKER="<!-- content-signals-marker -->"
           COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1)

--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -13,7 +13,7 @@ on:
       tag:
         description: "Release tag to validate and document"
         required: false
-        default: "v2.8.0"
+        default: "v2.9.0"
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard-report.yml
+++ b/.github/workflows/scorecard-report.yml
@@ -1,0 +1,104 @@
+name: Scorecard Weekly Report
+
+# Track the OpenSSF Scorecard aggregate over time so a security
+# regression is visible instead of silent. Read-only by design:
+#  - every run writes a job-summary trend line
+#  - a score DROP opens/updates one tracking issue (found by its marker)
+#  - a score RISE is noted in the summary; the baseline file is bumped
+#    through the normal PR flow by a human (main is protected)
+#
+# The baseline lives in .github/scorecard-baseline.json and is updated
+# via PR whenever the score improves.
+
+on:
+  schedule:
+    # Thursdays 06:11 UTC — after the weekly Scorecard run refreshes.
+    - cron: "11 6 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  trend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Fetch current score and compare with baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          curl -sf "https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it" -o /tmp/scorecard.json
+          python3 - <<'PY'
+          import json, os
+
+          data = json.load(open("/tmp/scorecard.json"))
+          current = float(data.get("score", 0))
+          checks = sorted(data.get("checks", []), key=lambda c: c.get("score", 0))
+
+          baseline_path = ".github/scorecard-baseline.json"
+          baseline = float(json.load(open(baseline_path))["aggregateScore"])
+
+          rows = "\n".join(
+              f"| {c['name']} | {c['score']} |"
+              for c in checks
+          )
+          summary = (
+              f"### OpenSSF Scorecard — weekly\n\n"
+              f"Aggregate: **{current}** (baseline {baseline})\n\n"
+              f"| Check | Score |\n|---|---|\n{rows}\n"
+          )
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write(summary)
+
+          if current < baseline:
+              with open("/tmp/regression", "w") as f:
+                  f.write(f"{current}\n{baseline}\n{rows}")
+          else:
+              with open("/tmp/ok", "w") as f:
+                  f.write(f"{current}\n{baseline}\n{rows}")
+          PY
+
+      - name: Open or update the regression issue
+        if: ${{ hashFiles('/tmp/regression') != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          CURRENT=$(sed -n 1p /tmp/regression)
+          BASELINE=$(sed -n 2p /tmp/regression)
+          BODY=$(cat <<EOF
+          ## Scorecard regression
+
+          Aggregate dropped to **${CURRENT}** (baseline was ${BASELINE}).
+
+          A drop means a new finding or a check regressing — investigate the
+          [latest Scorecard run](https://github.com/Kayforkind/reimagine-it/actions/workflows/scorecard.yml)
+          and the [score viewer](https://securityscorecards.dev/viewer/?uri=github.com/Kayforkind/reimagine-it).
+
+          <!-- scorecard-regression-marker -->
+          EOF
+          )
+          ISSUE=$(gh issue list --state open --search "scorecard regression in:title" --json number --jq '.[0].number // ""')
+          if [ -n "$ISSUE" ]; then
+            gh issue comment "$ISSUE" --body "$BODY"
+          else
+            gh issue create --title "OpenSSF Scorecard regression: ${CURRENT}" --body "$BODY" --label security
+          fi
+
+      - name: Note improvement in the summary
+        if: ${{ hashFiles('/tmp/ok') != '' }}
+        run: |
+          CURRENT=$(sed -n 1p /tmp/ok)
+          BASELINE=$(sed -n 2p /tmp/ok)
+          if python3 -c "import sys; sys.exit(0 if float('${CURRENT}') > float('${BASELINE}') else 1)"; then
+            echo "Score improved ${BASELINE} → ${CURRENT}. Bump .github/scorecard-baseline.json via PR to track it." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Score steady at ${CURRENT} (baseline ${BASELINE})." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/ANNOUNCEMENT.md
+++ b/ANNOUNCEMENT.md
@@ -1,75 +1,28 @@
-# v2.8.0 announcement — paste-ready
+# v2.9.0 announcement — paste-ready
 
-Short form for the GitHub release notes; long form for X/Reddit/HN follow-ups.
-Do not post until `npm view reimagine-it version` returns 2.8.0.
-
----
-
-## GitHub release (v2.8.0)
-
-**reimagine-it v2.8.0 — 17 directions, and a AAA motion system on every one**
-
-v2.7.0 made the honesty layer a product surface. v2.8.0 makes the output move
-like it costs six figures.
-
-**Two new directions — the roster is 17**
-
-- **`lookbook`** — a photoshoot/editorial spread: oversized masthead, numbered
-  looks from source anchors, hover-develop plates, anchor marquee. Auto awards
-  it on real photoshoot/runway/collection vocabulary (deliberately narrow —
-  "flu shots" is a genuine false positive the reproduction guard caught).
-- **`particles`** — a living constellation: a seeded canvas field where source
-  anchors ride as text particles and facts glow as nodes; pointer-reactive,
-  fully frozen under reduced motion.
-- Benchmark rerun: **17/17 tokens at 100/100 usability and full fidelity**, and
-  roster mean pairwise diversity *improved* 19.9% → **22.7%**.
-
-**Motion system — every token, every page**
-
-- **Kinetic type**: h1 words rise out of clipped masks, staggered (DOM-API only,
-  never `innerHTML`, so source text can never re-parse as markup).
-- **Magnetic buttons** that lean toward the cursor and spring back, **glow-follow
-  cards**, **sheen sweeps**, and a shared easing token system
-  (`--ease-out`, `--ease-spring`, `--ease-inout`).
-- All transform/opacity (GPU-composited), pointer-aware, and inside the
-  reduced-motion kill switch.
-
-**3js — from spinning cube to scene**
-
-Inertia orbit (drag flings, damped velocity settles), depth fog on far faces,
-breathing ground shadow, twinkling seeded starfield, and **orbiting fact
-billboards** — source anchors ride three rails around the object.
-
-**SVG — the diagram draws itself**
-
-Staggered node pulse and flowing connector dashes join the breathing core.
-
-**Still provable**
-
-All 10 proof artifacts regenerate byte-identically under the reproduction
-guard; browser bundles rebuilt; the full suite (gold audit, unit, fuzz, e2e,
-guards) is green.
-
-```bash
-npx reimagine-it --auto -i page.html -o redesign.html
-npx reimagine-it lookbook -i collection.html -o spread.html
-npx reimagine-it audit redesign.html
-```
+*Paste-ready for X/LinkedIn/dev.to. Cover: `docs/og.png`. Tags: `ai`, `webdev`, `security`, `opensource`.*
 
 ---
 
-## Social (X/Bluesky, ~280 chars)
+**reimagine-it v2.9.0 — an engine that proves it, then shows you the proof**
 
-reimagine-it v2.8.0: 17 design directions now (lookbook + particle field), and a AAA motion pack on every token — kinetic type, magnetic buttons, glow-follow cards, inertia-orbit 3D with fact billboards. Still zero invented facts, still one offline HTML file.
+We just cut v2.9.0. Where v2.8.0 made the output move, v2.9.0 makes the repo *auditable at a glance*: everything the CI enforces is now visible on the project page and the live site.
 
----
+Three things worth your time:
 
-## Reddit (r/ClaudeCode et al., body under the existing title)
+**1. The site now shows the receipts.** The docs site carries the same security badge row as the README (CI Gate, protected main, secret scanning, SLSA provenance, live OpenSSF Scorecard), a new **agents section** (the 8 MCP tools — an agent can generate, self-audit with 19 rules, and explain its design decision), and a **measured-quality section**: 17/17 tokens at 100/100 usability, byte-identical regeneration enforced by CI, fuzzed honesty contract, offline-by-construction. Hero stats and the token marquee now tell the truth: 17 directions, 9 committed journeys.
 
-We just cut v2.8.0. Three things worth your time:
+**2. The Scorecard sweep is done.** Every fixable OpenSSF check is at 10/10 — token permissions, SHA-pinned actions, complete PyPI hash-set pins (106 hashes for Pillow alone, after partial pins broke on a third-platform wheel), CodeQL + Semgrep on every push, a structural workflow lint in the required gate (negative-tested against the exact parse-time outage it prevents), cosign-signed release artifacts, SLSA provenance on npm. Weekly automated trend tracking opens a regression issue if the aggregate ever drops.
 
-1. **Two new directions.** `lookbook` turns any photoshoot/campaign/collection page into an editorial spread with numbered looks; `particles` turns any anchor list into a living, pointer-reactive constellation. Auto earns both from the source's own vocabulary — a clinic bulletin does not get a lookbook because it says "shots."
-2. **Every token got a motion upgrade.** Kinetic headline reveals, magnetic buttons, glow-follow cards, sheen sweeps — plus a real scene in the 3D token (inertia orbit, depth fog, starfield, orbiting fact billboards) and self-drawing SVG diagrams. All compositor-friendly, all disabled under reduced motion.
-3. **Still the honest engine.** 17/17 tokens benchmark at 100/100 usability and full fidelity with record output diversity (22.7%); every committed proof still regenerates byte-identically in CI.
+**3. Branch protection at maximum.** `enforce_admins` is on: every change — including the owner's — lands through a reviewed PR with the full battery green. For client audits, "who can change this code" now has a one-word answer: *nobody without a green gate and a review*.
 
-`npx reimagine-it --auto -i page.html` — no keys, no build, one offline file.
+Try it: `npx reimagine-it --auto -i page.html -o redesign.html` — or paste HTML into the in-browser playground: https://kayforkind.github.io/reimagine-it/
+
+MIT · offline · deterministic · no API keys.
+
+## Verification checklist (filled at release)
+
+- `npm view reimagine-it version` returns 2.9.0
+- `npm view reimagine-it dist.attestations` shows provenance
+- Release assets carry cosign signatures (verify with `cosign verify-blob`)
+- Docs site version chip reads v2.9.0, identical to README and npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to reimagine-it.
 
 ---
 
-## v2.8.0 (current)
+## v2.9.0 (current)
+
+### The auditability release — the repo's guarantees are now shown, not just enforced
+
+- **Docs-site parity.** The live site now carries everything the README proves: the security badge row in the hero, an **MCP/agents section** (8 tools, the MCP stanza, the design decision report), a **measured-quality section** (100/100 × 17 tokens, the regenerate-or-CI-fails guarantee, fuzzed honesty, supply-chain posture, offline/deterministic), and footer links to MCP, audit posture, and SECURITY.md. Hero stats corrected (17 tokens, 9 committed journeys).
+- **Weekly Scorecard trend report** (`scorecard-report.yml`): every Thursday the aggregate is compared against `.github/scorecard-baseline.json`; a drop opens a regression issue automatically, improvements are reported in the run summary. Baseline starts at 6.7.
+- **Scorecard sweep completed.** Token-Permissions, Pinned-Dependencies, Binary-Artifacts, Dangerous-Workflow, Dependency-Update-Tool, License, Packaging, Vulnerabilities all at 10/10. Complete PyPI hash-set pins (Pillow 106, PyYAML 53) replace partial pins after the third-platform-wheel failure; a structural workflow lint (`scripts/check-workflows.py`) now runs **in the required gate** — actionless steps, duplicate keys, loose action tags, and incomplete hash pins cannot merge (negative-tested against the exact outage it prevents).
+- **SAST on every push**: CodeQL + Semgrep upload SARIF to code scanning; the audit linter itself is fuzzed weekly (800 adversarial generations, zero crashes).
+- **Signed releases**: release assets are cosign keyless-signed (Fulcio/Rekor) alongside npm SLSA provenance.
+- **Branch protection at maximum**: `enforce_admins` on — every change, including the owner's, lands through a reviewed PR with the green gate.
+- **CII Best Practices answers** drafted from real enforcement (`docs/CII-BADGE-ANSWERS.md`) — every claim maps to a CI check or repo setting.
+- **Share assets regenerated** from the current engine (og.png + demo.gif now include both community proofs).
+
+### Upgrading
+
+No breaking changes. `npm i reimagine-it@2.9.0` (or `npx`) — outputs are byte-compatible with 2.8.0 given the same seed.
+
+## v2.8.0
 
 ### Two new design directions — the roster is 17
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Kayforkind/reimagine-it)
 [![Benchmark](https://img.shields.io/github/actions/workflow/status/Kayforkind/reimagine-it/benchmark.yml?branch=main&label=benchmark%20100%2F100)](https://github.com/Kayforkind/reimagine-it/actions/workflows/benchmark.yml)
 [![Design Health](https://img.shields.io/github/actions/workflow/status/Kayforkind/design-health-action/audit.yml?branch=main&label=Design%20Health&logo=github)](https://github.com/Kayforkind/design-health-action/actions/workflows/audit.yml)
-[![version 2.8.0](https://img.shields.io/badge/version-2.8.0-b22234.svg)](CHANGELOG.md)
+[![version 2.9.0](https://img.shields.io/badge/version-2.9.0-b22234.svg)](CHANGELOG.md)
 [![npm](https://img.shields.io/npm/v/reimagine-it?color=e8a63f&label=npm)](https://www.npmjs.com/package/reimagine-it)
 [![MIT](https://img.shields.io/badge/license-MIT-1a2138.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/kayforkind/reimagine-it)](https://skills.sh/kayforkind/reimagine-it)
@@ -229,7 +229,7 @@ npm install -g reimagine-it
 reimagine-it --auto -i page.html -o redesign.html
 ```
 
-Package: [npmjs.com/package/reimagine-it](https://www.npmjs.com/package/reimagine-it) · current release **2.8.0**.
+Package: [npmjs.com/package/reimagine-it](https://www.npmjs.com/package/reimagine-it) · current release **2.9.0**.
 
 More commands:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # reimagine-it Roadmap
 
-> **Shipped: v2.8.0** — nine committed journeys at 100% source fidelity, a full-fact rendering
+> **Shipped: v2.9.0** — nine committed journeys at 100% source fidelity, a full-fact rendering
 > engine (no silent fact caps in any generator), a CI drift guard that re-derives every proof
 > asset, a 6,750-run fidelity stress harness with zero violations, a 17-direction roster
 > (new: `lookbook`, `particles`), and a AAA motion pack (kinetic type, magnetic buttons,
@@ -90,7 +90,7 @@ the live plan: what is open, ordered by leverage per hour.
 
 ### What they have that reimagine-it didn't (and what happened)
 
-| Gap | Status after v2.8.0 |
+| Gap | Status after v2.9.0 |
 |-----|---------------------|
 | Product website | **Shipped** — docs site with playground, nine case studies, community proof |
 | Deterministic quality checks | **Shipped** — 19-rule Design Health, JS + Python parity-tested |

--- a/docs/CII-BADGE-ANSWERS.md
+++ b/docs/CII-BADGE-ANSWERS.md
@@ -1,0 +1,85 @@
+# CII Best Practices badge — paste-ready answers
+
+Project: <https://bestpractices.dev> → "Get a badge" → `Kayforkind/reimagine-it`.
+Sign in with GitHub as the owner; every answer below maps to a CI check or a
+repo setting that already exists — nothing aspirational. Submit **Passing**
+level first; revisit Silver once history accrues.
+
+---
+
+## Basics
+
+| Question | Answer |
+|---|---|
+| Human-readable name | `reimagine-it` |
+| Home page (URL) | `https://kayforkind.github.io/reimagine-it/` |
+| Repo (URL) | `https://github.com/Kayforkind/reimagine-it` |
+| Where is the repo hosted? | GitHub |
+| License | MIT (`LICENSE`) — Scorecard License check: 10/10 |
+
+## Reporting
+
+| Question | Answer |
+|---|---|
+| Security contact (URL) | `https://github.com/Kayforkind/reimagine-it/security/advisories/new` — private vulnerability reporting is enabled |
+| Vulnerability disclosure policy (URL) | `https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md` |
+
+## Enhancement / maintenance
+
+| Question | Answer |
+|---|---|
+| Public VCS? | Yes — GitHub (git), public, readable without an account |
+| Latest release date | See the Releases tab; versions are tagged `vX.Y.Z` and cut from main after the full CI battery passes |
+| Release notes? | Yes — `CHANGELOG.md` documents every release; GitHub Releases embed the entry |
+
+## Quality
+
+| Question | Answer |
+|---|---|
+| Test suite? | Yes — `npm test` runs 12 phases: gold audit sweep, engine + MCP unit tests (83 tests), extractor fuzz/property tests, 25 e2e CLI tests, browser-bundle freshness, tarball guard, stills guard, reproduction guard, JS/Python audit parity, smoke demo, audit fuzzer |
+| Test suite runs in CI? | Yes — required **CI Gate** (`battery`) + `review` on every PR and main push: `https://github.com/Kayforkind/reimagine-it/actions/workflows/gate.yml` |
+| All tests pass? | Yes — gate is green on main; it is a *required* check, so main cannot be pushed without passing |
+| Contribution procedure? | Yes — `CONTRIBUTING.md` (PR flow, CODEOWNERS review requirement, stale-review dismissal) |
+| Max modification time of a bug report? | GitHub Issues; the project triages weekly (Scorecard "Maintained" tracks commit cadence) |
+| Coding standards? | Yes — enforced mechanically: 19-rule Design Health audit on every generated page, audit-parity test (JS vs Python mirror must agree), structural workflow lint, version-sync guard, reproduction guard |
+| Build is reproducible? | Yes — `package-lock.json` committed; `npm ci` only; deterministic engine (same input + seed → byte-identical output, enforced by `scripts/check-repro.js` in CI) |
+
+## Security
+
+| Question | Answer |
+|---|---|
+| New crypto from scratch? | No — the project implements no cryptography |
+| Secure design principles? | Yes — documented in `.github/SECURITY.md` (honesty contract: source facts never invented; offline by construction; least-privilege workflows) |
+| Hardened versions exist? | Yes — depend on the latest tagged release; the CI Gate + branch protection make main always releasable |
+| Subprojects? | No subprojects |
+| Secure development knowledge? | Yes — SAST (CodeQL + Semgrep) on every push; dependency alerts + updates via Dependabot; secret scanning with push protection |
+| Static analysis (SAST)? | Yes — CodeQL (`sast.yml`) and Semgrep upload SARIF to code scanning on every push and PR, plus a weekly schedule |
+| Dynamic analysis? | Partial — the audit fuzzer (`scripts/fuzz_audit.py`) exercises the linter with adversarial generations weekly and in `npm test`; the extractor fuzzer hits the parser with hostile HTML |
+| Two-factor / strong auth on repo? | Owner-managed — enable 2FA on the GitHub account (owner action, not automatable) |
+| Signed releases? | Yes — release artifacts are cosign keyless-signed (Fulcio/Rekor); npm publishes with SLSA provenance (`npm view reimagine-it dist.attestations`) |
+| Common vulnerability reporting? | Yes — GitHub private vulnerability reporting + Dependabot alerts enabled |
+| Public cryptographic signatures? | Yes — cosign signatures on release assets, verifiable with `cosign verify-blob` against the Fulcio identity |
+
+## Analysis
+
+| Question | Answer |
+|---|---|
+| Coverage measurement? | Not tracked as a percentage — the suite is integration-first (byte-identity, parity, e2e) rather than coverage-number driven; answer honestly "no coverage %, comprehensive behavior tests instead" |
+| Performance tests? | Partial — the token benchmark (`scripts/benchmark-tokens.js`, required in gate) proves 17/17 tokens at 100/100 usability per run |
+
+## Future
+
+| Question | Answer |
+|---|---|
+| Continued maintenance for 2+ years? | Yes — active roadmap (`ROADMAP.md`), weekly Dependabot/stress/Scorecard automation, sponsorable |
+| 2+ core maintainers? | Currently one human owner + automation; answer honestly. CODEOWNERS + branch protection reduce bus risk on code paths; consider inviting a co-maintainer (the external PR #13 security contributor is a candidate) |
+
+---
+
+### After submitting
+
+1. The badge endpoint will be `https://bestpractices.dev/projects/<ID>/badge`.
+2. Add it to the README badge row next to the OpenSSF Scorecard badge, and to
+   the docs-site hero badge row (`docs/index.html`, `.hero-badges`).
+3. `scripts/check-version-sync.py` does not check badge URLs — no guard change
+   needed.

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -107,7 +107,7 @@ If you use Content-Derived Design in your work:
   author = {Kayforkind},
   year = {2026},
   howpublished = {\url{https://github.com/Kayforkind/reimagine-it}},
-  note = {reimagine-it v2.8.0. See examples/end-users/ for verified outputs.}
+  note = {reimagine-it v2.9.0. See examples/end-users/ for verified outputs.}
 }
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,6 +104,9 @@ h1 .grad { background: linear-gradient(100deg, var(--crimson), var(--hot) 55%, #
 
 /* ---- STATS ---- */
 .stats { display: flex; gap: 44px; margin-top: 34px; flex-wrap: wrap; }
+.hero-badges { display: flex; gap: 8px; margin-top: 22px; flex-wrap: wrap; align-items: center; }
+.hero-badges img { height: 20px; display: block; border-radius: 3px; }
+.hero-badges a:focus-visible { outline: 2px solid var(--hot); outline-offset: 3px; border-radius: 4px; }
 .stat { font-family: var(--mono); position: relative; padding-left: 14px; }
 .stat::before { content: ""; position: absolute; left: 0; top: 4px; bottom: 4px; width: 2px; background: linear-gradient(var(--crimson), var(--hot)); }
 .stat .val { font-size: 34px; font-weight: 600; color: var(--ink); display: block; letter-spacing: -.02em; }
@@ -311,7 +314,7 @@ footer a { color: var(--hot); }
     <div class="hero-aurora" aria-hidden="true"><i></i><i></i><i></i></div>
     <section class="hero" id="hero">
       <div>
-        <p class="kicker">Content-Derived Design for AI Agents <span class="ver-chip" title="matches package.json and the npm release — kept in sync by CI">v2.8.0</span></p>
+        <p class="kicker">Content-Derived Design for AI Agents <span class="ver-chip" title="matches package.json and the npm release — kept in sync by CI">v2.9.0</span></p>
         <h1>Your HTML <em>is</em> the brief.<br>The engine reads it and <span class="grad">redesigns</span> it.</h1>
         <p class="sub">
           <strong>Content-Derived Design</strong> — palette, motifs, and motion are extracted from the concrete nouns, dates, and colors already in the source HTML. Not a mood board. A real artifact. <code>npx reimagine-it</code> ships one standalone HTML file — in <strong>17 directions</strong> (including a photoshoot <code>lookbook</code> and a living <code>particles</code> field), each carrying a AAA motion pack: kinetic type, magnetic buttons, glow-follow cards, inertia-orbit 3D with fact billboards. Offline. No Figma. No CDN.
@@ -322,10 +325,17 @@ footer a { color: var(--hot); }
           <a class="btn btn--ghost" href="https://github.com/Kayforkind/reimagine-it">GitHub</a>
         </div>
         <div class="stats">
-          <div class="stat"><span class="val">15</span><span class="lab">Design tokens</span></div>
+          <div class="stat"><span class="val">17</span><span class="lab">Design tokens</span></div>
           <div class="stat"><span class="val">19</span><span class="lab">Health rules</span></div>
-          <div class="stat"><span class="val">7</span><span class="lab">Committed journeys</span></div>
+          <div class="stat"><span class="val">9</span><span class="lab">Committed journeys</span></div>
           <div class="stat"><span class="val">0</span><span class="lab">CDN deps</span></div>
+        </div>
+        <div class="hero-badges">
+          <a href="https://github.com/Kayforkind/reimagine-it/actions/workflows/gate.yml"><img src="https://img.shields.io/github/actions/workflow/status/Kayforkind/reimagine-it/gate.yml?branch=main&label=CI%20Gate" alt="CI Gate" loading="lazy"></a>
+          <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md"><img src="https://img.shields.io/badge/main-protected%20%2B%20codeowners-2ea043" alt="main protected + codeowners" loading="lazy"></a>
+          <a href="https://github.com/Kayforkind/reimagine-it/security"><img src="https://img.shields.io/badge/secret%20scanning-push%20protection%20on-2ea043" alt="secret scanning + push protection" loading="lazy"></a>
+          <a href="https://docs.npmjs.com/generating-provenance-statements"><img src="https://img.shields.io/badge/npm%20releases-SLSA%20provenance-2ea043" alt="SLSA provenance" loading="lazy"></a>
+          <a href="https://securityscorecards.dev/viewer/?uri=github.com/Kayforkind/reimagine-it"><img src="https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it/badge" alt="OpenSSF Scorecard" loading="lazy"></a>
         </div>
       </div>
       <aside class="transform" aria-label="Live examples">
@@ -537,6 +547,73 @@ footer a { color: var(--hot); }
       <p class="tg-note">Source: <a href="https://github.com/Kayforkind/reimagine-it/blob/main/examples/end-users/meridian/source.html">Meridian Tower — A Living Building</a> · the amber, steel, copper, and sky palette comes from the hex colors in the source · the 3D object orbits (drag or arrow keys) and the diagram spins and breathes — real engine output, not mockups. <a href="#cases">See all nine journeys ↓</a></p>
     </section>
 
+    <section class="install-section" id="mcp">
+      <h2>For agents — MCP server &amp; one-file skill</h2>
+      <p class="sub">The same engine, exposed to any MCP-compatible host (Claude Code, Codex, Copilot, Gemini CLI, and friends) or used as a single-file agent skill. Deterministic, offline, no API keys — an agent can generate, self-audit its own output with 19 rules, and explain the design decision.</p>
+      <div class="install-grid">
+        <div class="install-card reveal">
+          <span class="agent">MCP · any host</span>
+          <h3>One JSON stanza</h3>
+          <pre>{ "mcpServers": { "reimagine-it": {
+  "command": "npx",
+  "args": ["-y", "--package", "reimagine-it",
+           "reimagine-it-mcp"] } } }</pre>
+          <p class="alt">Node native HTTP/streamable transport; no Python required.</p>
+        </div>
+        <div class="install-card reveal">
+          <span class="agent">8 tools</span>
+          <h3>Generate, rank, verify</h3>
+          <pre>reimagine        one direction from raw HTML
+design_auto      choose · generate · verify · explain
+design_variations  ranked directions + contrast sheet
+design_lock      capture a brand surface as JSON
+extract_content  inspect the source evidence
+list_tokens      discover the 17 directions
+audit_html       19-rule Design Health check
+list_rules       the full rule registry</pre>
+          <p class="alt">An agent can prove its own output before shipping it.</p>
+        </div>
+        <div class="install-card reveal">
+          <span class="agent">Design decision report</span>
+          <h3>Inspectable &quot;why&quot;</h3>
+          <pre>voice      editorial | grotesque | techno | …
+palette    OKLCH, source accent rotated
+art        primitives actually used
+score      136-point design-QA
+fidelity   every source fact present</pre>
+          <p class="alt">Written beside the artifact with <code>--emit</code>; Auto explains its pick from real evidence.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="install-section" id="quality">
+      <h2>Measured quality — every direction benchmarked</h2>
+      <p class="sub">All 17 tokens × 4 representative sources score <strong>100/100 usability and full fidelity</strong>, with 22.7% mean pairwise output diversity (no two directions produce the same page). Benchmarked against the same bar Auto itself applies: standalone HTML, source title and anchors retained, focus-visible, reduced-motion, no placeholder copy, no external fetch.</p>
+      <div class="method-steps">
+        <div class="method-card reveal">
+          <span class="step">CI-enforced</span>
+          <h3>Proof regenerates — or CI fails</h3>
+          <p>Every committed example artifact must regenerate byte-identically from the committed engine. Every screenshot stays in sync. <code>npm pack</code> must match the intentional file list exactly.</p>
+        </div>
+        <div class="method-card reveal">
+          <span class="step">Property-tested</span>
+          <h3>Honesty is fuzzed</h3>
+          <p>The extractor's "no invented facts" contract runs against hostile and malformed input; a 250-seed weekly stress harness holds the fidelity floor across every token × source cell. The audit linter itself is fuzzed too.</p>
+        </div>
+        <div class="method-card reveal">
+          <span class="step">Supply-chain</span>
+          <h3>Hardened end to end</h3>
+          <p>Actions SHA-pinned + Dependabot-bumped; CI installs with <code>--ignore-scripts</code> and hash-verified PyPI pins; releases carry cosign signatures + SLSA provenance; CodeQL and Semgrep scan every push.</p>
+        </div>
+        <div class="method-card reveal">
+          <span class="step">Guarantee</span>
+          <h3>Offline &amp; deterministic</h3>
+          <p>Output is one standalone HTML file — no CDN, no API keys, no telemetry. Same input + seed → byte-identical output: clients can re-derive any published artifact themselves.</p>
+        </div>
+      </div>
+      <p class="tg-note">The audit is deterministic and heuristic — not a claim of full WCAG conformance or visual taste. Review a generated page before shipping it to a client. Full details: <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">README audit posture →</a></p>
+    </section>
+
     <section class="install-section" id="install">
       <h2>Install — one command</h2>
       <p class="sub">Works in Claude Code, Cursor, Codex, Copilot, Gemini CLI, Factory Droid, Windsurf, Pi, and any Agent Skills host. One chair: <code>skills/reimagine-it/</code>.</p>
@@ -657,7 +734,7 @@ droid plugin install reimagine-it@reimagine-it --scope user</pre>
     </section>
 
     <footer>
-      <span>v2.8.0 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
+      <span>v2.9.0 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
       <a href="https://kayforkind.github.io/reimagine-it/discussions">Feedback &amp; roadmap →</a>
     </footer>
   </div>
@@ -665,7 +742,7 @@ droid plugin install reimagine-it@reimagine-it --scope user</pre>
 <script>
 (function(){
   /* token marquee */
-  var tokens = ['webpage','landing','dashboard','infographic','cinematic','artistic','photography','svg','3js','simulation','glass','editorial','motion','gradient','showcase'];
+  var tokens = ['webpage','landing','dashboard','infographic','cinematic','artistic','photography','svg','3js','simulation','glass','editorial','motion','gradient','showcase','lookbook','particles'];
   var track = document.getElementById('marqueeTrack');
   if (track) {
     var half = tokens.map(function(t){ return '<span>'+t+' <i>&#10022;</i></span>'; }).join('');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Reimagine This Page",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Content-Derived Design \u2014 reads the current HTML page and redesigns it from its own content. Palette, motifs, and motion derived from nouns, dates, and colors already in the source.",
   "permissions": [
     "activeTab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reimagine-it",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reimagine-it",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "bin": {
         "reimagine-it": "bin/reimagine-it.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reimagine-it",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Content-Derived Design CLI and agent skill. Reads existing HTML and writes a stronger standalone page from the nouns, dates, numbers, and colors already in the file.",
   "license": "MIT",
   "author": "Kayforkind",

--- a/skills/reimagine-it/SKILL.md
+++ b/skills/reimagine-it/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   hosts:
     - claude-code
     - cursor

--- a/skills/reimagine-it/audit/SKILL.md
+++ b/skills/reimagine-it/audit/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/extract/SKILL.md
+++ b/skills/reimagine-it/extract/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/generate/SKILL.md
+++ b/skills/reimagine-it/generate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/infographic/SKILL.md
+++ b/skills/reimagine-it/infographic/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/lock/SKILL.md
+++ b/skills/reimagine-it/lock/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/variations/SKILL.md
+++ b/skills/reimagine-it/variations/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.8.0"
+  version: "2.9.0"
   parent: reimagine-it
   hosts:
     - claude-code


### PR DESCRIPTION
## What this ships

**Docs-site ↔ README parity** (the ask): the live site now shows the trust layer the repo actually enforces —
- Security badge row in the hero (CI Gate · protected main · secret scanning · SLSA · live Scorecard)
- New **For agents** section: MCP stanza, the 8 tools, the design decision report
- New **Measured quality** section: 17/17 × 100/100, regenerate-or-CI-fails, fuzzed honesty, supply chain, offline/deterministic
- Footer links: MCP · Audit posture · Security
- Drift fixes: hero stats 15→17 tokens / 7→9 journeys; marquee JS now lists all 17 tokens

**Scorecard weekly trend** (`scorecard-report.yml` + baseline 6.7): auto-issue on any aggregate drop; summary on improvement.

**CII Best Practices answers** (`docs/CII-BADGE-ANSWERS.md`): every answer maps to an existing CI check or repo setting.

**v2.9.0** across all live surfaces (version-sync guard enforces it), CHANGELOG + ANNOUNCEMENT rewritten.

## Verification
- `python scripts/check-version-sync.py` → OK 2.9.0
- `python scripts/check-workflows.py` → 12 workflows OK
- `npm test` → all 12 phases pass
- `node scripts/check-tarball.js` → 63 files OK