### PR TITLE
fix(ci): grant the board bot pull-requests:write

### DIFF
--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -16,7 +16,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # benchmark job edits release notes; token-board opens PRs
+  contents: write # benchmark edits release notes; token-board pushes branches
+  pull-requests: write # token-board opens + auto-merges its PR
 
 jobs:
   benchmark:


### PR DESCRIPTION
Third and final release-pipeline defect: the board bot could push its branch (contents:write) but PR creation needs the pull-requests scope. Observed in run 33957743946.