### PR TITLE
fix(ci): zip boards from repo root

### DIFF
--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -246,5 +246,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          (cd dist && zip -q token-boards.zip docs/tokens/*.png docs/tokens-board.png docs/tokens-phone.png)
+          zip -q dist/token-boards.zip docs/tokens/*.png docs/tokens-board.png docs/tokens-phone.png
           gh release upload "$GITHUB_REF_NAME" "$TARBALL" "${TARBALL}.sig" dist/token-boards.zip --clobber


### PR DESCRIPTION
Run 33959050099: the zip subshell cd'd into dist/ where docs/ paths do not resolve. Zip from the root instead.