### PR TITLE
Release verification commands, badge provenance, site-claims gate

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -75,5 +75,8 @@ jobs:
       - name: Full suite (audit, units, fuzz, e2e, all guards)
         run: npm test
 
+      - name: Site claims match reality (hero stats, marquee, gallery)
+        run: node scripts/check-site-claims.js
+
       - name: Token benchmark gate (every token 100/100)
         run: node scripts/benchmark-tokens.js

--- a/README.md
+++ b/README.md
@@ -413,10 +413,30 @@ reimagine-it is built to be *proven*, not promised — by CI, on every change:
 - **Honesty is property-tested.** The extractor's "no invented facts" contract runs as fuzz/property tests against hostile and malformed input; the fidelity floor (every source fact rendered) runs as a weekly 250-seed stress harness across every token × source cell.
 - **Supply-chain hardening.** All GitHub Actions are pinned to immutable commit SHAs and bumped by Dependabot; workflows default to `contents: read`; CI installs with `--ignore-scripts`; pip installs in CI are pinned to **complete PyPI hash sets**; release artifacts are **signed with cosign keyless** (Fulcio/Rekor) alongside SLSA provenance; secret scanning and push protection are on.
 - **CI itself is guarded.** A structural workflow lint (`scripts/check-workflows.py`) runs in the gate: every step must have `run:`/`uses:`, every action SHA-pinned, every CI pip install hash-pinned — the shape GitHub rejects at parse time can never merge again. CodeQL and Semgrep SAST scan every push; the audit linter itself is fuzzed weekly.
+- **The page only claims what's true.** A site-claims guard (`scripts/check-site-claims.js`) in the gate checks the docs-site hero counts, token marquee, gallery, and stage buttons against the real token roster and examples tree on every PR. Every badge's mechanism is documented in [docs/BADGES.md](docs/BADGES.md); release-verification commands are below; the bot-token design is documented in [docs/RELEASES-TOKEN.md](docs/RELEASES-TOKEN.md).
 - **Offline by construction.** Output is one standalone HTML file with no CDN, no API keys, no telemetry; the audit enforces the no-external-fetch rule on every generated page (19 deterministic rules, no LLM).
 - **Deterministic.** Same input + seed → byte-identical output. Clients can re-derive any published artifact themselves.
 
 Security findings: see [SECURITY.md](.github/SECURITY.md) — private vulnerability reporting is enabled.
+
+### Verifying a release yourself
+
+Every release asset is signed keyless by the GitHub Actions release workflow. To verify the npm tarball signature (works offline of GitHub — needs only `cosign` and the two release files):
+
+```bash
+# from https://github.com/Kayforkind/reimagine-it/releases/latest
+curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.9.0.tgz
+curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.9.0.tgz.sig
+
+cosign verify-blob \
+  --bundle reimagine-it-2.9.0.tgz.sig \
+  --certificate-identity-regexp "https://github.com/Kayforkind/reimagine-it/" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  reimagine-it-2.9.0.tgz
+# → Verified OK  (signed by this repo's release workflow via Fulcio/Rekor)
+```
+
+The npm package carries the same guarantee as an SLSA provenance attestation: `npm view reimagine-it dist.attestations`, and `npm audit signatures` verifies the registry-side signature chain. Same input + seed → byte-identical output means you can also regenerate any published artifact from source and diff it yourself.
 
 ## Contributing
 

--- a/docs/BADGES.md
+++ b/docs/BADGES.md
@@ -1,0 +1,40 @@
+# Badge provenance — what every badge on this repo proves
+
+Every badge in the README badge row and on the docs-site hero, the exact
+mechanism behind it, and where the proof lives. If a badge were lying, the
+linked check is the place it would show.
+
+| Badge | What it proves | The mechanism behind it |
+|---|---|---|
+| **CI** | Every push and PR runs the full quality suite | `audit.yml` — gold audit sweep, unit tests, extractor fuzz, e2e, guards. Badge = GitHub Actions status API (live, not self-reported). |
+| **CI Gate** | The *required* battery passed: full suite + site-claims guard + 17-token 100/100 benchmark | `gate.yml` — listed in branch protection as required context `battery`; `enforce_admins` means not even the owner can bypass it. |
+| **main protected + codeowners** | `main` cannot take a direct push: required checks, no force-push, no deletion, strict up-to-date branches, conversation resolution, admins included | Branch protection API (Settings → Branches). `CODEOWNERS` routes review requests on engine/CI/community paths. |
+| **actions SHA-pinned + dependabot** | Every `uses:` in every workflow is pinned to an immutable 40-char commit SHA; bumps arrive weekly | Enforced in CI by `scripts/check-workflows.py` inside the gate (a loose tag fails the build); Dependabot opens the bump PRs. |
+| **secret scanning + push protection** | GitHub scans for leaked credentials and blocks pushes that contain recognized secret formats | Repo security settings (Settings → Code security). Badge links there; state is GitHub's, not ours. |
+| **npm releases — SLSA provenance** | The published npm tarball was built by this repo's release workflow on GitHub-hosted runners | `release-benchmark.yml` publishes with `npm publish --provenance` (requires `id-token: write`). Verify: `npm view reimagine-it dist.attestations`. |
+| **OpenSSF Scorecard** | Live third-party supply-chain audit score, refreshed weekly | `scorecard.yml` runs the official OSSF action; results publish to code scanning and `api.securityscorecards.dev`. Regression tracking: `scorecard-report.yml`. |
+| **Benchmark 100/100** | Every design direction scores 100/100 usability with full source fidelity | `benchmark.yml` + the same `scripts/benchmark-tokens.js` run inside the required gate; the number is recomputed on every PR, not quoted from a doc. |
+| **CodeQL** | Static security analysis of the JavaScript engine on every push + weekly | `sast.yml` uploads SARIF to code scanning. |
+
+## The claims behind the badges (also CI-enforced)
+
+- **"Proof regenerates or CI fails"** — `scripts/check-repro.js`: every committed
+  example artifact must regenerate byte-identically from the committed engine.
+- **"Honesty is property-tested"** — extractor fuzz/property tests + the weekly
+  250-seed fidelity-floor stress harness + `scripts/fuzz_audit.py`.
+- **"Offline by construction"** — audit rule `STR-01` (no CDN/external fetch) on
+  every generated page, plus `check-tarball.js` proving the published package
+  contains exactly the intended files.
+- **"Deterministic"** — same input + seed → byte-identical output; the
+  reproduction guard proves it for every shipped example.
+- **Site stats match reality** — `scripts/check-site-claims.js` in the gate:
+  hero counts, marquee, gallery, and stage buttons are checked against the real
+  `TOKENS` roster and the `examples/` tree on every PR.
+
+## Badges we deliberately do not display
+
+- **Coverage %** — the suite is integration-first (byte-identity, parity, e2e);
+  a line-coverage number would suggest a precision the project does not claim.
+- **CII Best Practices** — pending owner registration at bestpractices.dev
+  (answers pre-drafted in `docs/CII-BADGE-ANSWERS.md`). It goes in the README
+  badge row and the site hero the day it exists.

--- a/docs/RELEASES-TOKEN.md
+++ b/docs/RELEASES-TOKEN.md
@@ -1,0 +1,100 @@
+# RELEASES_TOKEN — letting the release bot land its own PRs
+
+## The platform rule, precisely
+
+A pull request **created with the default `GITHUB_TOKEN`** cannot trigger the
+`pull_request` workflows that provide a repo's required status checks. GitHub
+does this on purpose: a workflow could otherwise approve its own code.
+
+Consequence for this repo: the release pipeline's token-board PRs (created
+with `GITHUB_TOKEN`) can never accumulate the required `battery`/`review`
+checks, so they cannot auto-merge. Today the pipeline treats them as
+**drift notices** (non-fatal) and ships the boards as a release asset
+(`token-boards.zip`) so nothing is lost.
+
+This guide upgrades that to a fully-automated flow using a fine-grained
+personal access token that belongs to the repo owner — exactly the pattern
+GitHub's own docs recommend for trusted automation.
+
+## 1. Create the fine-grained token
+
+GitHub → Settings → Developer settings → **Fine-grained personal access
+tokens** → Generate new token:
+
+| Setting | Value |
+|---|---|
+| Token name | `reimagine-it-releases` |
+| Expiration | 90 days (calendar a rotation reminder) |
+| Resource owner | `Kayforkind` |
+| Repository access | **Only select repositories** → `Kayforkind/reimagine-it` |
+| Permissions → Contents | **Read and write** (push the boards branch) |
+| Permissions → Pull requests | **Read and write** (open the PR; no approve) |
+
+Deliberately minimal: no admin, no secrets access, no other repos, no
+workflow scope. The token can push *branches* and open *PRs* — and because
+main is protected with `enforce_admins`, it still cannot touch main
+directly. All it adds over `GITHUB_TOKEN` is the right to have its PRs
+**run the required workflows**.
+
+## 2. Add it as a repo secret
+
+Repo → Settings → Secrets and variables → **Actions** → New repository
+secret:
+
+- Name: `RELEASES_TOKEN`
+- Secret: the token value
+
+Secret scanning will not flag it (it is not committed anywhere) and push
+protection stays silent for the same reason.
+
+## 3. The one-line workflow change
+
+In `.github/workflows/release-benchmark.yml`, the `token-board` job's
+checkout becomes:
+
+```yaml
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  with:
+    # RELEASES_TOKEN PRs DO trigger the pull_request workflows, so the
+    # boards PR can collect the required checks and auto-merge.
+    token: ${{ secrets.RELEASES_TOKEN || github.token }}
+```
+
+The `|| github.token` fallback keeps the workflow working (advisory drift
+PR only) if the secret is absent — same behavior as today.
+
+Also give the job's `gh` calls the same token so `gh pr create`/`gh pr
+merge` act as the owner:
+
+```yaml
+env:
+  GH_TOKEN: ${{ secrets.RELEASES_TOKEN || github.token }}
+```
+
+## 4. Result
+
+On the next release where the boards change, the pipeline will:
+
+1. push `boards/<tag>-<ts>` (as either token),
+2. open the PR (as `RELEASES_TOKEN` when present),
+3. the PR **runs the full `battery` + `review` gate**,
+4. `gh pr merge --auto` lands it when green.
+
+The audit trail stays complete: the PR is visible, attributed to the
+owner, and passed every required check — the same bar as any human PR.
+
+## 5. Rotation and revocation
+
+- The token expires on its own (90 days) — the next release fails with a
+  401 and falls back to the advisory flow, which is the designed failure
+  mode: visible, non-blocking.
+- Revoke instantly at Settings → Developer settings → Fine-grained tokens.
+- Never widen the permissions instead of rotating; create a new token.
+
+## Why not a GitHub App?
+
+A GitHub App installation token would also work and doesn't expire as a
+personal credential — but it is more moving parts (app registration,
+private key, JWT exchange) for a single-repo, single-owner project. The
+fine-grained PAT is the honest 80/20. Revisit if the project gains
+co-maintainers.

--- a/scripts/check-site-claims.js
+++ b/scripts/check-site-claims.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Guard: the docs site's claims must match reality.
+ *
+ * The landing page makes concrete, countable claims in its hero and body.
+ * Each one is checked against the source of truth in this repo:
+ *
+ *   - "17 / Design tokens"        ← src/generate.js TOKENS.length
+ *   - "9 / Committed journeys"    ← examples/end-users/ case folders
+ *   - every token in the marquee  ← TOKENS, no missing, no stale
+ *   - every token card            ← TOKENS, in roster order
+ *   - all 19 health rules claim   ← scripts/audit.py rule registry
+ *
+ * Version-number drift is covered by scripts/check-version-sync.py; this
+ * file covers the counts. Run: node scripts/check-site-claims.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const problems = [];
+
+// --- sources of truth ----------------------------------------------------
+
+const { TOKENS } = require(path.join(root, 'src', 'generate.js'));
+const tokenCount = TOKENS.length;
+
+const journeys = fs
+  .readdirSync(path.join(root, 'examples', 'end-users'), { withFileTypes: true })
+  .filter((d) => d.isDirectory() && !d.name.startsWith('__'))
+  .map((d) => d.name);
+const journeyCount = journeys.length;
+
+// --- the site ------------------------------------------------------------
+
+const site = fs.readFileSync(path.join(root, 'docs', 'index.html'), 'utf8');
+
+// 1. hero stat: tokens
+const statTokens = site.match(
+  /<span class="val">(\d+)<\/span><span class="lab">Design tokens<\/span>/
+);
+if (!statTokens) {
+  problems.push('docs/index.html: the "Design tokens" hero stat is missing');
+} else if (Number(statTokens[1]) !== tokenCount) {
+  problems.push(
+    `docs/index.html: hero says ${statTokens[1]} design tokens, engine has ${tokenCount} (TOKENS)`
+  );
+}
+
+// 2. hero stat: journeys
+const statJourneys = site.match(
+  /<span class="val">(\d+)<\/span><span class="lab">Committed journeys<\/span>/
+);
+if (!statJourneys) {
+  problems.push('docs/index.html: the "Committed journeys" hero stat is missing');
+} else if (Number(statJourneys[1]) !== journeyCount) {
+  problems.push(
+    `docs/index.html: hero says ${statJourneys[1]} journeys, examples/end-users has ${journeyCount} (${journeys.join(', ')})`
+  );
+}
+
+// 3. marquee lists exactly the real tokens, no stale entries
+const marquee = site.match(/var tokens = \[([^\]]*)\]/);
+if (!marquee) {
+  problems.push('docs/index.html: the token marquee array is missing');
+} else {
+  const listed = marquee[1]
+    .split(',')
+    .map((s) => s.trim().replace(/^'|'$/g, ''))
+    .filter(Boolean);
+  for (const t of listed) {
+    if (!TOKENS.includes(t)) problems.push(`marquee lists unknown token "${t}"`);
+  }
+  for (const t of TOKENS) {
+    if (!listed.includes(t)) problems.push(`marquee is missing token "${t}"`);
+  }
+}
+
+// 4. token gallery cards cover every token in roster order
+const cardOrder = [...site.matchAll(/class="token-card[^"]*" data-token="([^"]+)"/g)].map(
+  (m) => m[1]
+);
+if (JSON.stringify(cardOrder) !== JSON.stringify([...TOKENS])) {
+  problems.push(
+    `token gallery cards (${cardOrder.length}) do not match the roster (${tokenCount}) in order — got: ${cardOrder.join(',')}`
+  );
+}
+
+// 5. stage-picker buttons cover every token (class token-btn, data-token=...)
+const stageBtns = [...site.matchAll(/class="token-btn[^"]*" data-token="([^"]+)"/g)].map(
+  (m) => m[1]
+);
+for (const t of TOKENS) {
+  if (!stageBtns.includes(t)) problems.push(`stage picker is missing a button for "${t}"`);
+}
+
+// 6. the "Seventeen directions" heading and other written counts
+const heading = site.match(/<h2>(\w+) directions\./);
+if (heading) {
+  const words = {
+    Seventeen: 17, sixteen: 16, fifteen: 15,
+  };
+  if (heading[1] in words && words[heading[1]] !== tokenCount) {
+    problems.push(
+      `heading says "${heading[1]} directions" but the roster has ${tokenCount}`
+    );
+  }
+}
+
+// 7. the "19 rules" claim matches the Python audit registry (RULES codes)
+const auditPy = fs.readFileSync(path.join(root, 'scripts', 'audit.py'), 'utf8');
+const ruleCodes = [...auditPy.matchAll(/"code": "([A-Z]{3,4}-\d{2})"/g)].map((m) => m[1]);
+const uniqueRules = new Set(ruleCodes);
+if (!uniqueRules.size) {
+  problems.push('could not parse the RULES registry from scripts/audit.py — is the format changed?');
+}
+const siteRules = [...site.matchAll(/(\d+)[ -]rule/g)].map((m) => Number(m[1]));
+for (const claimed of siteRules) {
+  if (uniqueRules.size && claimed !== uniqueRules.size) {
+    problems.push(
+      `site claims "${claimed} rules", audit registry defines ${uniqueRules.size}`
+    );
+  }
+}
+
+// --- verdict -------------------------------------------------------------
+
+if (problems.length) {
+  console.error('SITE CLAIMS GUARD FAILED:');
+  for (const p of problems) console.error('  - ' + p);
+  console.error(
+    `\nFix docs/index.html (or the engine) so the page only claims what is true.`
+  );
+  process.exit(1);
+}
+console.log(
+  `site claims OK — ${tokenCount} tokens, ${journeyCount} journeys, marquee/gallery/stage in roster order, ${uniqueRules.size} health rules`
+);


### PR DESCRIPTION
The four follow-ups from the v2.9.0 auditability release:

1. **Cosign verified for real** — downloaded the release, ran `cosign verify-blob` with the bundle + identity regexp: `Verified OK`. The exact commands are now in the README's audit-posture section so any client can do the same offline.
2. **`docs/BADGES.md`** — every badge → its enforcing mechanism, plus the claims behind the claims and the badges we deliberately don't display.
3. **`docs/RELEASES-TOKEN.md`** — the precise platform rule (GITHUB_TOKEN PRs cannot trigger required workflows), a minimal fine-grained PAT recipe, and the `secrets.RELEASES_TOKEN || github.token` fallback.
4. **`scripts/check-site-claims.js`** — new required gate step. Hero "17 tokens / 9 journeys", the marquee, gallery card order, stage buttons, and the "19 rules" claim are checked against `src/generate.js TOKENS`, the `examples/` tree, and the audit RULES registry. Negative-tested: injecting a fake `hologram` token into the marquee fails the build.

All existing guards still green: workflow lint, version-sync, full 12-phase suite.