### PR TITLE
Scorecard baseline: 7.0 (measured)

### DIFF
--- a/.github/scorecard-baseline.json
+++ b/.github/scorecard-baseline.json
@@ -1,6 +1,6 @@
 {
-  "aggregateScore": 7.2,
+  "aggregateScore": 7.0,
   "updated": "2026-09-06",
   "source": "https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it",
-  "note": "Baseline for the weekly scorecard-report.yml trend check. Bump via PR when the live score improves; a drop below this opens a regression issue automatically. 7.2 = Token-Permissions 10 (recognized release actions), Security-Policy 10 (linked reporting path), Branch-Protection ruleset (PR + battery + admin enforcement), strict up-to-date branches. Signed-Releases reaches 10 on the first release with intoto.jsonl provenance; CII badge + Fuzzing tradeoff tracked in #47."
+  "note": "Baseline for the weekly scorecard-report.yml trend check. Bump via PR when the live score improves; a drop below this opens a regression issue automatically. 7.0 = measured on 378d31d (Token-Permissions 10, Security-Policy 10, Branch-Protection 4, Signed-Releases 8 until next release ships intoto.jsonl; CII + Fuzzing tracked in #47). Remaining headroom is structural: Maintained/Code-Review/Contributors need repo age and outside reviewers."
 }


### PR DESCRIPTION
The post-#49 Scorecard run measures **7.0** on `main`. This sets the trend baseline to the measured value so `scorecard-report.yml` doesn't open a false regression on its first weekly run. Check-level truth: Token-Permissions 10, Security-Policy 10, Signed-Releases 8 (intoto lands next release), Branch-Protection 4 (hardened ruleset; remaining warns are solo-maintainer structural), CII/Fuzzing per #47.