### PR TITLE
Release v2.13.0 — provenance ships on the tag

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Kayforkind"
   }, "metadata": {
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.12.0"
+  "version": "2.13.0"
  },
  "plugins": [
   {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "displayName": "reimagine-it",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
   "author": {
     "name": "Kayforkind"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/ANNOUNCEMENT.md
+++ b/ANNOUNCEMENT.md
@@ -1,4 +1,4 @@
-# reimagine-it v2.12.0 — the last similarity floor falls
+# reimagine-it v2.13.0 — the last similarity floor falls
 
 *Paste-ready dev.to article. Cover image: `docs/og.png`. Tags: `ai`, `webdev`, `css`, `opensource`.*
 
@@ -10,7 +10,7 @@ two of the seventeen directions still shipped pages that were a quarter the
 same. The issue said it plainly: they share section-listing DNA because both
 are reading pages.
 
-v2.12.0 closes it with composition, not color swaps.
+v2.13.0 closes it with composition, not color swaps.
 
 ## Landing grows its own hero form
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to reimagine-it.
 
 ---
 
-## v2.12.0 (current)
+## v2.13.0 (current)
+
+### The auditability release — OpenSSF Scorecard 6.2 → 7.0
+
+- **Token-Permissions 0 → 10.** Every workflow now runs read-only except release writes, which go through *recognized* release tooling — `softprops/action-gh-release` for assets and `actions/attest-build-provenance` for SLSA provenance. Raw `gh release edit/upload` grants (what Scorecard penalizes) are gone; the benchmark table now attaches as a job artifact instead of editing release notes, and token boards upload as artifacts.
+- **Signed-Releases 8 → 10 (from this release on).** The release job attests the tarball with `actions/attest-build-provenance`, emitting the `*.intoto.jsonl` provenance bundle Scorecard requires — it ships as a release asset on v2.13.0 and every future tag.
+- **Security-Policy 4 → 10.** Root `SECURITY.md` (the location the detector reads), a private vulnerability-reporting link, a public noreply mailto fallback, and an explicit scope list — the policy previously had zero contact methods (`Warn: no linked content found`).
+- **Branch-Protection: a real ruleset.** PRs required, the `battery` check enforced, up-to-date branches required, admin enforcement on, deletion and force-push blocked — Scorecard can now read enforcement instead of erroring.
+- **Baseline honesty.** `.github/scorecard-baseline.json` tracks the measured 7.0 (not an aspiration), with the remaining gap documented per-check: CII badge registration and the Fuzzing heuristic are owner decisions (#47); Maintained/Code-Review/Contributors need repo age and outside reviewers.
+
+## v2.12.0
 
 ### The last-similarity-floor release
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Kayforkind/reimagine-it)
 [![Benchmark](https://img.shields.io/github/actions/workflow/status/Kayforkind/reimagine-it/benchmark.yml?branch=main&label=benchmark%20100%2F100)](https://github.com/Kayforkind/reimagine-it/actions/workflows/benchmark.yml)
 [![Design Health](https://img.shields.io/github/actions/workflow/status/Kayforkind/design-health-action/audit.yml?branch=main&label=Design%20Health&logo=github)](https://github.com/Kayforkind/design-health-action/actions/workflows/audit.yml)
-[![version 2.12.0](https://img.shields.io/badge/version-2.12.0-b22234.svg)](CHANGELOG.md)
+[![version 2.13.0](https://img.shields.io/badge/version-2.13.0-b22234.svg)](CHANGELOG.md)
 [![npm](https://img.shields.io/npm/v/reimagine-it?color=e8a63f&label=npm)](https://www.npmjs.com/package/reimagine-it)
 [![MIT](https://img.shields.io/badge/license-MIT-1a2138.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/kayforkind/reimagine-it)](https://skills.sh/kayforkind/reimagine-it)
@@ -228,7 +228,7 @@ Not Keith Mangold’s [Reimagine It](https://reimagineit.ai) interview SaaS (Pro
 npx reimagine-it --auto -i page.html -o redesign.html
 ```
 
-No install required. Package: [npmjs.com/package/reimagine-it](https://www.npmjs.com/package/reimagine-it) · **2.12.0**.
+No install required. Package: [npmjs.com/package/reimagine-it](https://www.npmjs.com/package/reimagine-it) · **2.13.0**.
 
 ```bash
 npx reimagine-it extract -i page.html -o signals.json
@@ -428,14 +428,14 @@ Every release asset is signed keyless by the GitHub Actions release workflow. To
 
 ```bash
 # from https://github.com/Kayforkind/reimagine-it/releases/latest
-curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.12.0.tgz
-curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.12.0.tgz.sig
+curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.13.0.tgz
+curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.13.0.tgz.sig
 
 cosign verify-blob \
-  --bundle reimagine-it-2.12.0.tgz.sig \
+  --bundle reimagine-it-2.13.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/Kayforkind/reimagine-it/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  reimagine-it-2.12.0.tgz
+  reimagine-it-2.13.0.tgz
 # → Verified OK  (signed by this repo's release workflow via Fulcio/Rekor)
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # reimagine-it Roadmap
 
-> **Shipped: v2.12.0** — nine committed journeys at 100% source fidelity, a full-fact rendering
+> **Shipped: v2.13.0** — nine committed journeys at 100% source fidelity, a full-fact rendering
 > engine (no silent fact caps in any generator), a CI drift guard that re-derives every proof
 > asset, a 6,750-run fidelity stress harness with zero violations, a 17-direction roster
 > (new: `lookbook`, `particles`), and a AAA motion pack (kinetic type, magnetic buttons,
@@ -90,7 +90,7 @@ the live plan: what is open, ordered by leverage per hour.
 
 ### What they have that reimagine-it didn't (and what happened)
 
-| Gap | Status after v2.12.0 |
+| Gap | Status after v2.13.0 |
 |-----|---------------------|
 | Product website | **Shipped** — docs site with playground, nine case studies, community proof |
 | Deterministic quality checks | **Shipped** — 19-rule Design Health, JS + Python parity-tested |

--- a/docs/DATASET-CARD.md
+++ b/docs/DATASET-CARD.md
@@ -85,7 +85,7 @@ npm install && npm test          # reproduction guard must pass
 node scripts/build-dataset.js -o dataset.jsonl --gold
 ```
 
-Engine version at build: **v2.12.0** (28 rows: 17 engine + 11 gold). Rows are
+Engine version at build: **v2.13.0** (28 rows: 17 engine + 11 gold). Rows are
 deterministic given the repo state; the reproduction guard in CI keeps
 `dataset.jsonl` and the examples in lockstep.
 

--- a/docs/LISTINGS.md
+++ b/docs/LISTINGS.md
@@ -6,7 +6,7 @@ The directories below take manual submissions from the owner; use this copy
 verbatim. Keep it in sync when tokens or install paths change — the CI
 version-sync guard catches stale `version:` fields in this repo, not here.
 
-Last verified against the engine: **v2.12.0**, 17 tokens, CLI-first.
+Last verified against the engine: **v2.13.0**, 17 tokens, CLI-first.
 
 ---
 

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -107,7 +107,7 @@ If you use Content-Derived Design in your work:
   author = {Kayforkind},
   year = {2026},
   howpublished = {\url{https://github.com/Kayforkind/reimagine-it}},
-  note = {reimagine-it v2.12.0. See examples/end-users/ for verified outputs.}
+  note = {reimagine-it v2.13.0. See examples/end-users/ for verified outputs.}
 }
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -314,7 +314,7 @@ footer a { color: var(--hot); }
     <div class="hero-aurora" aria-hidden="true"><i></i><i></i><i></i></div>
     <section class="hero" id="hero">
       <div>
-        <p class="kicker">Content-Derived Design for AI Agents <span class="ver-chip" title="matches package.json and the npm release — kept in sync by CI">v2.12.0</span></p>
+        <p class="kicker">Content-Derived Design for AI Agents <span class="ver-chip" title="matches package.json and the npm release — kept in sync by CI">v2.13.0</span></p>
         <h1>Your HTML <em>is</em> the brief.<br>The engine reads it and <span class="grad">redesigns</span> it.</h1>
         <p class="sub">
           <strong>Content-Derived Design</strong> — palette, motifs, and motion are extracted from the concrete nouns, dates, and colors already in the source HTML. Not a mood board. A real artifact. <code>npx reimagine-it</code> ships one standalone HTML file — in <strong>17 directions</strong> (including a photoshoot <code>lookbook</code> and a living <code>particles</code> field), each carrying a AAA motion pack: kinetic type, magnetic buttons, glow-follow cards, inertia-orbit 3D with fact billboards. Offline. No Figma. No CDN.
@@ -753,7 +753,7 @@ droid plugin install reimagine-it@reimagine-it --scope user</pre>
     </section>
 
     <footer>
-      <span>v2.12.0 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
+      <span>v2.13.0 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
       <a href="https://kayforkind.github.io/reimagine-it/discussions">Feedback &amp; roadmap →</a>
     </footer>
   </div>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Reimagine This Page",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Content-Derived Design \u2014 reads the current HTML page and redesigns it from its own content. Palette, motifs, and motion derived from nouns, dates, and colors already in the source.",
   "permissions": [
     "activeTab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reimagine-it",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reimagine-it",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "MIT",
       "bin": {
         "reimagine-it": "bin/reimagine-it.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
-  "version": "2.12.0",
-  "description": "Kayforkind Content-Derived Design CLI. HTML in, standalone HTML out from the source’s own nouns, dates, numbers, and colors. Not the reimagineit.ai interview SaaS.",
+  "version": "2.13.0",
+  "description": "Kayforkind Content-Derived Design CLI. HTML in, standalone HTML out from the source\u00e2\u20ac\u2122s own nouns, dates, numbers, and colors. Not the reimagineit.ai interview SaaS.",
   "license": "MIT",
   "author": "Kayforkind",
   "repository": {

--- a/skills/reimagine-it/SKILL.md
+++ b/skills/reimagine-it/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   hosts:
     - claude-code
     - cursor

--- a/skills/reimagine-it/audit/SKILL.md
+++ b/skills/reimagine-it/audit/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/extract/SKILL.md
+++ b/skills/reimagine-it/extract/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/generate/SKILL.md
+++ b/skills/reimagine-it/generate/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/infographic/SKILL.md
+++ b/skills/reimagine-it/infographic/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/lock/SKILL.md
+++ b/skills/reimagine-it/lock/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/variations/SKILL.md
+++ b/skills/reimagine-it/variations/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.12.0"
+  version: "2.13.0"
   parent: reimagine-it
   hosts:
     - claude-code


### PR DESCRIPTION
Activates the Signed-Releases work from #48: **every release now carries SLSA provenance.**

- Version synced to 2.13.0 across all CI-guarded surfaces (plugin manifests, skills, README, docs site, extension, action.yml)
- CHANGELOG entry for the auditability release (Scorecard 6.2 → 7.0 posture work)
- The release workflow now runs `actions/attest-build-provenance` — v2.13.0's tarball ships with an `*.intoto.jsonl` bundle, flipping Scorecard's Signed-Releases from 8 to 10 on this tag
- Battery: ALL TESTS PASSED (68 unit / 20 MCP / 28 e2e), reproduction guard 17/17 byte-identical, site claims + version sync green

Closes the remaining actionable item from the OpenSSF investigation.