### PR TITLE
fix(ci): token-board checkout + attestations write

### DIFF
--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -43,6 +43,8 @@ jobs:
       # checks out the tag) so the boards attached to the release match
       # what shipped.
 
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
@@ -180,6 +182,7 @@ jobs:
     permissions:
       contents: write # attach assets to the release (via gh-release action)
       id-token: write # keyless cosign signing + SLSA attestation
+      attestations: write # persist the intoto.jsonl attestation record
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Repairs the two failures from the v2.13.0 release run: token-board had no checkout (missing scripts on runner), and the SLSA attestation could not persist without `attestations: write`. Re-runs on the next release event will produce the intoto.jsonl bundle.