### PR TITLE
chore: baseline note reflects v2.13.1 provenance

### DIFF
--- a/.github/scorecard-baseline.json
+++ b/.github/scorecard-baseline.json
@@ -2,5 +2,5 @@
   "aggregateScore": 7.0,
   "updated": "2026-09-06",
   "source": "https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it",
-  "note": "Baseline for the weekly scorecard-report.yml trend check. Bump via PR when the live score improves; a drop below this opens a regression issue automatically. 7.0 = measured on 378d31d (Token-Permissions 10, Security-Policy 10, Branch-Protection 4, Signed-Releases 8 until next release ships intoto.jsonl; CII + Fuzzing tracked in #47). Remaining headroom is structural: Maintained/Code-Review/Contributors need repo age and outside reviewers."
+  "note": "Baseline for the weekly scorecard-report.yml trend check. Bump via PR when the live score improves; a drop below this opens a regression issue automatically. 7.0 = measured on the post-#54 main (Token-Permissions 10, Security-Policy 10, Signed-Releases 8 - provenance ships on v2.13.1+ and reaches 10 once v2.10-v2.12 slide out of the 5-release window; Branch-Protection 4 is the solo-maintainer ceiling; CII + Fuzzing tracked in #47; Maintained/Code-Review/Contributors need repo age and outside reviewers)."
 }


### PR DESCRIPTION
Documentation-only: the measured 7.0 baseline note now records that intoto.jsonl provenance ships from v2.13.1 and the Signed-Releases path to 10.