### PR TITLE
Point the NavigatorLabs funnel link at navigatorslab.com/reimagine/

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <div align="center">
 
-**[Try the live playground](https://kayforkind.github.io/reimagine-it/#playground)** · **[See the results](https://kayforkind.github.io/reimagine-it/#results)** · **[Run it locally](#the-60-second-proof)** · **[Install it](#install)** · **[The lab behind it](https://reimagine.navigatorslab.com)**
+**[Try the live playground](https://kayforkind.github.io/reimagine-it/#playground)** · **[See the results](https://kayforkind.github.io/reimagine-it/#results)** · **[Run it locally](#the-60-second-proof)** · **[Install it](#install)** · **[The lab behind it](https://navigatorslab.com/reimagine/)**
 
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -753,7 +753,7 @@ droid plugin install reimagine-it@reimagine-it --scope user</pre>
     </section>
 
     <footer>
-      <span>v2.13.1 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://reimagine.navigatorslab.com">NavigatorLabs</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
+      <span>v2.13.1 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://navigatorslab.com/reimagine/">NavigatorLabs</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
       <a href="https://kayforkind.github.io/reimagine-it/discussions">Feedback &amp; roadmap →</a>
     </footer>
   </div>


### PR DESCRIPTION
The subdomain experiment is retired: the lab serves the docs site at **navigatorslab.com/reimagine/** (worker proxy on the same zone — same pattern as /tools/, zero DNS). This PR repoints the two funnel links (README quick-nav + docs footer). `/Reimagine` pretty-URL also 301s there.