### PR TITLE
Output-collision safety: source guard, --no-clobber, atomic writes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-    "version": "2.13.1"
+    "version": "2.14.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "displayName": "reimagine-it",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
   "author": {
     "name": "Kayforkind"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reimagine-it",
   "description": "Redesigns existing HTML from its own content. 17 visual directions, standalone offline pages. CLI + agent skill.",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "author": {
     "name": "Kayforkind",
     "url": "https://github.com/Kayforkind"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to reimagine-it.
 
 - **The extractor's honesty properties now also run through fast-check** (`test/unit/extract-property.test.js`). Scorecard's Fuzzing check only recognizes OSS-Fuzz / ClusterFuzzLite / fast-check for JavaScript, so the repo's seeded generational fuzzer was invisible to it. The fast-check suite keeps the existing fuzzer and adds shrinking property tests (never invents emails/numbers/links, pure function, hostile blobs) on top. fast-check is a **devDependency only** — the published tarball stays dependency-free (tarball guard re-verified).
 
+
+### Output-collision safety for agent and CI loops
+
+- **The source guard is now mechanical.** The docs always promised the source stays untouched; the CLI now enforces it — an `--output` path that resolves to the input file (same file, any spelling: relative vs absolute, `..` segments, case on Windows) exits 2 before anything is written. No flag lifts this guard; `-o -` and `--diff` remain unaffected because they never touch a file.
+- **`--no-clobber` for reviewed-artifact workflows.** By default `-o` still replaces an existing file — the deterministic engine's byte-identical regeneration depends on it, and so does CI's reproduction guard. The new flag inverts that for agent/CI loops that must not clobber a reviewed artifact: any existing target (artifact, `--emit` reports, `*-options/` candidates, variations sheet, report JSON) refuses with exit 2 and a `--no-clobber:` message, pre-flighted so the refusal happens before any file is written. Available on the default command, `lock`, `extract`, `variations`, and the `npm run auto` runner.
+- **Atomic writes everywhere.** Every artifact write goes through a shared helper (`src/io.js`): content lands in a sibling temp file and is renamed into place, so a concurrent reader or a crashed run never observes a truncated file, and two parallel agents sharing an `-o` can no longer interleave partial HTML.
+- **E2E coverage:** overwrite-by-default regeneration, `--no-clobber` refusal (existing file byte-identical afterwards), fresh-file success, source-guard refusals including path-spelling dodges, and zero `.tmp` residue on both success and refusal.
+
 ## v2.13.1 (current)
 
 ### Release-pipeline repair

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to reimagine-it.
 
 ---
 
-## Unreleased
+## v2.14.0 (current)
 
 ### Scorecard Fuzzing check closed (#47)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Kayforkind/reimagine-it/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Kayforkind/reimagine-it)
 [![Benchmark](https://img.shields.io/github/actions/workflow/status/Kayforkind/reimagine-it/benchmark.yml?branch=main&label=benchmark%20100%2F100)](https://github.com/Kayforkind/reimagine-it/actions/workflows/benchmark.yml)
 [![Design Health](https://img.shields.io/github/actions/workflow/status/Kayforkind/design-health-action/audit.yml?branch=main&label=Design%20Health&logo=github)](https://github.com/Kayforkind/design-health-action/actions/workflows/audit.yml)
-[![version 2.13.1](https://img.shields.io/badge/version-2.13.1-b22234.svg)](CHANGELOG.md)
+[![version 2.14.0](https://img.shields.io/badge/version-2.14.0-b22234.svg)](CHANGELOG.md)
 [![npm](https://img.shields.io/npm/v/reimagine-it?color=e8a63f&label=npm)](https://www.npmjs.com/package/reimagine-it)
 [![MIT](https://img.shields.io/badge/license-MIT-1a2138.svg)](LICENSE)
 [![skills.sh](https://skills.sh/b/kayforkind/reimagine-it)](https://skills.sh/kayforkind/reimagine-it)
@@ -228,7 +228,7 @@ Not Keith Mangold’s [Reimagine It](https://reimagineit.ai) interview SaaS (Pro
 npx reimagine-it --auto -i page.html -o redesign.html
 ```
 
-No install required. Package: [npmjs.com/package/reimagine-it](https://www.npmjs.com/package/reimagine-it) · **2.13.1**.
+No install required. Package: [npmjs.com/package/reimagine-it](https://www.npmjs.com/package/reimagine-it) · **2.14.0**.
 
 ```bash
 npx reimagine-it extract -i page.html -o signals.json
@@ -434,14 +434,14 @@ Every release asset is signed keyless by the GitHub Actions release workflow. To
 
 ```bash
 # from https://github.com/Kayforkind/reimagine-it/releases/latest
-curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.13.1.tgz
-curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.13.1.tgz.sig
+curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.14.0.tgz
+curl -sLO https://github.com/Kayforkind/reimagine-it/releases/latest/download/reimagine-it-2.14.0.tgz.sig
 
 cosign verify-blob \
-  --bundle reimagine-it-2.13.1.tgz.sig \
+  --bundle reimagine-it-2.14.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/Kayforkind/reimagine-it/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  reimagine-it-2.13.1.tgz
+  reimagine-it-2.14.0.tgz
 # → Verified OK  (signed by this repo's release workflow via Fulcio/Rekor)
 ```
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ npx reimagine-it -i page.html --auto --diff
 # Reproduce an approved draw
 npx reimagine-it -i page.html -t webpage --seed 42 -o approved.html
 
+# Agent/CI-safe writes: refuse an existing target; the source path is
+# always refused as output
+npx reimagine-it -i page.html --auto --no-clobber -o reimagined/auto.html
+
 # Opt in to Google Fonts for the chosen voice (default output is fully offline)
 npx reimagine-it -i page.html -t landing --web-fonts -o redesign.html
 
@@ -327,6 +331,8 @@ npx reimagine-it audit redesign.html --verbose
 ```
 
 Use `-o -` when another tool should receive only generated HTML; progress stays on stderr.
+
+By default `-o` replaces an existing file — that is what makes the deterministic engine's byte-identical regeneration work. Two guards cover agent and CI loops: an output path that resolves to the source file is always refused (exit 2, no flag can lift it), and `--no-clobber` refuses (exit 2) to replace any existing output file. Writes are atomic (temp file + rename), so a reader never sees a partial artifact.
 
 ## MCP server
 

--- a/bin/reimagine-it.js
+++ b/bin/reimagine-it.js
@@ -22,6 +22,7 @@ const { sourceFidelity } = require('../src/result');
 const { auditHtml, formatReport, exitCodeFor, RULES } = require('../src/audit');
 const { extractLock, readLock, applyLock, formatLock, LOCK_VERSION } = require('../src/lock');
 const { buildVariations, contrastSheet, MAX_VARIATIONS } = require('../src/variations');
+const { sameFileAsInput, assertWritable, writeFileAtomic } = require('../src/io');
 
 const MAX_INPUT_BYTES = 10 * 1024 * 1024;
 const COMMANDS = ['audit', 'lock', 'variations', 'extract', 'mcp'];
@@ -57,6 +58,15 @@ const outputToStdout = args.output === '-' || args.stdout;
 const candidateCount = args.candidates === undefined ? (autoMode ? 3 : 1) : args.candidates;
 const source = readSource();
 const inputPath = source.path;
+
+// The source is the brief; a redesign never writes back onto it. Enforced
+// here — not just promised in the skill docs — because `-o` and `-i` resolve
+// independently and an agent loop can hand both the same path. (`-o -` and
+// --diff never touch a file.)
+const guardDefaultName = autoMode ? 'auto.html' : `${requestedToken}.html`;
+if (!args.diff && !outputToStdout && sameFileAsInput(inputPath, path.resolve(args.output || path.join('reimagined', guardDefaultName)))) {
+  fail(`output would overwrite the source. Choose a different --output path: ${args.output || path.join('reimagined', guardDefaultName)}`, 2);
+}
 
 if (args.command === 'lock') runLock();
 
@@ -146,14 +156,15 @@ if (outputToStdout) {
 const defaultOutputName = autoMode ? 'auto.html' : `${token}.html`;
 const outputPath = path.resolve(args.output || path.join('reimagined', defaultOutputName));
 try {
-  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, output, 'utf8');
+  assertWritable(args.emit ? [outputPath, path.join(path.dirname(outputPath), 'design-token.json'), path.join(path.dirname(outputPath), 'quality-report.json')] : [outputPath], args.noClobber);
+  writeFileAtomic(outputPath, output, args.noClobber);
   if (args.emit) {
     const dir = path.dirname(outputPath);
-    fs.writeFileSync(path.join(dir, 'design-token.json'), JSON.stringify(designMeta, null, 2), 'utf8');
-    fs.writeFileSync(path.join(dir, 'quality-report.json'), JSON.stringify({ quality: designMeta.quality, fidelity: fidelity.percentage, harmony: designMeta.harmony }, null, 2), 'utf8');
+    writeFileAtomic(path.join(dir, 'design-token.json'), JSON.stringify(designMeta, null, 2), args.noClobber);
+    writeFileAtomic(path.join(dir, 'quality-report.json'), JSON.stringify({ quality: designMeta.quality, fidelity: fidelity.percentage, harmony: designMeta.harmony }, null, 2), args.noClobber);
   }
 } catch (error) {
+  if (error.code === 'EEXIST') fail(`--no-clobber: ${error.message}`, 2);
   fail(`could not write output: ${error.message}`, 2);
 }
 
@@ -238,10 +249,12 @@ function runLock() {
   }
 
   const target = path.resolve(args.output || `${name}.lock.json`);
+  if (sameFileAsInput(inputPath, target)) fail(`output would overwrite the source. Choose a different --output path: ${target}`, 2);
   try {
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, serialised + '\n', 'utf8');
+    assertWritable([target], args.noClobber);
+    writeFileAtomic(target, serialised + '\n', args.noClobber);
   } catch (error) {
+    if (error.code === 'EEXIST') fail(`--no-clobber: ${error.message}`, 2);
     fail(`could not write lock: ${error.message}`, 2);
   }
 
@@ -290,10 +303,12 @@ function runExtract() {
 
   const base = path.basename(inputPath).replace(/\.[^.]+$/, '');
   const target = path.resolve(args.output || `${base}.extract.json`);
+  if (sameFileAsInput(inputPath, target)) fail(`output would overwrite the source. Choose a different --output path: ${target}`, 2);
   try {
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, serialised, 'utf8');
+    assertWritable([target], args.noClobber);
+    writeFileAtomic(target, serialised, args.noClobber);
   } catch (error) {
+    if (error.code === 'EEXIST') fail(`--no-clobber: ${error.message}`, 2);
     fail(`could not write extraction: ${error.message}`, 2);
   }
 
@@ -323,16 +338,21 @@ function runVariations() {
 
   const dir = path.resolve(args.output && args.output !== '-' ? args.output : path.join('reimagined', 'variations'));
   try {
+    assertWritable([
+      ...result.variations.map((entry) => path.join(dir, entry.file)),
+      path.join(dir, 'index.html'),
+      path.join(dir, 'variations.json'),
+    ], args.noClobber);
     fs.mkdirSync(dir, { recursive: true });
     result.variations.forEach((entry) => {
-      fs.writeFileSync(path.join(dir, entry.file), entry.output, 'utf8');
+      writeFileAtomic(path.join(dir, entry.file), entry.output, args.noClobber);
     });
     const sheet = contrastSheet(result, content, {
       source: path.basename(inputPath),
       command: `npx reimagine-it -i ${path.basename(inputPath)} --variations ${result.count} --seed ${result.seed}`,
     });
-    fs.writeFileSync(path.join(dir, 'index.html'), sheet, 'utf8');
-    fs.writeFileSync(path.join(dir, 'variations.json'), JSON.stringify({
+    writeFileAtomic(path.join(dir, 'index.html'), sheet, args.noClobber);
+    writeFileAtomic(path.join(dir, 'variations.json'), JSON.stringify({
       source: path.basename(inputPath),
       title: content.title,
       seed: result.seed,
@@ -350,8 +370,9 @@ function runVariations() {
         bytes: entry.bytes,
         failedChecks: entry.failed,
       })),
-    }, null, 2) + '\n', 'utf8');
+    }, null, 2) + '\n', args.noClobber);
   } catch (error) {
+    if (error.code === 'EEXIST') fail(`--no-clobber: ${error.message}`, 2);
     fail(`could not write variations: ${error.message}`, 2);
   }
 
@@ -535,6 +556,8 @@ Options:
                           serifClassic, highContrast, expressive, monoForward
   --plan <json>           Model-harness plan override: {"token":"landing","voice":"grotesque"}
   --emit                  Also write design-token.json + quality-report.json next to output
+  --no-clobber            Refuse (exit 2) instead of replacing an existing output file;
+                          the source path is always refused, flag or no flag
   --audit                 Run Design Health on the generated page (exit 3 on failures)
   --dry, -d               Show extracted signals; do not generate
   --full                  Include paragraphs and list items in extract output
@@ -618,6 +641,8 @@ function parseArgs(raw) {
       case '--diff': opts.diff = true; break;
       case '--web-fonts': opts.webFonts = true; break;
       case '--emit': opts.emit = true; break;
+      case '--no-clobber': opts.noClobber = true; break;
+      case '--no-clobber': opts.noClobber = true; break;
       case '--json': opts.json = true; break;
       case '--stdout': opts.stdout = true; break;
       case '--audit': opts.audit = true; break;

--- a/docs/index.html
+++ b/docs/index.html
@@ -314,7 +314,7 @@ footer a { color: var(--hot); }
     <div class="hero-aurora" aria-hidden="true"><i></i><i></i><i></i></div>
     <section class="hero" id="hero">
       <div>
-        <p class="kicker">Content-Derived Design for AI Agents <span class="ver-chip" title="matches package.json and the npm release — kept in sync by CI">v2.13.1</span></p>
+        <p class="kicker">Content-Derived Design for AI Agents <span class="ver-chip" title="matches package.json and the npm release — kept in sync by CI">v2.14.0</span></p>
         <h1>Your HTML <em>is</em> the brief.<br>The engine reads it and <span class="grad">redesigns</span> it.</h1>
         <p class="sub">
           <strong>Content-Derived Design</strong> — palette, motifs, and motion are extracted from the concrete nouns, dates, and colors already in the source HTML. Not a mood board. A real artifact. <code>npx reimagine-it</code> ships one standalone HTML file — in <strong>17 directions</strong> (including a photoshoot <code>lookbook</code> and a living <code>particles</code> field), each carrying a AAA motion pack: kinetic type, magnetic buttons, glow-follow cards, inertia-orbit 3D with fact billboards. Offline. No Figma. No CDN.
@@ -753,7 +753,7 @@ droid plugin install reimagine-it@reimagine-it --scope user</pre>
     </section>
 
     <footer>
-      <span>v2.13.1 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://navigatorslab.com/reimagine/">NavigatorLabs</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
+      <span>v2.14.0 · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/CHANGELOG.md">Changelog</a> · MIT · Content-Derived Design · <a href="https://github.com/Kayforkind/reimagine-it">GitHub</a> · <a href="https://github.com/Kayforkind/reimagine-it#mcp-server">MCP</a> · <a href="https://github.com/Kayforkind/reimagine-it#audit-posture-for-clients-and-security-review">Audit posture</a> · <a href="https://github.com/Kayforkind/reimagine-it/blob/main/.github/SECURITY.md">Security</a> · <a href="https://navigatorslab.com/reimagine/">NavigatorLabs</a> · <a href="https://github.com/sponsors/Kayforkind">Sponsor</a></span>
       <a href="https://kayforkind.github.io/reimagine-it/discussions">Feedback &amp; roadmap →</a>
     </footer>
   </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -33,6 +33,7 @@ npx reimagine-it --auto -i page.html -o redesign.html   # plain CLI, no agent ne
 3. Fidelity must be ≥ 80% (the engine prints the percentage of detected source facts preserved; all committed examples hold 100%).
 4. `audit` must report zero failures before the result is called done.
 5. Output is a single offline HTML file — no CDN, no external fonts unless `--web-fonts`.
+6. `--output` may never be the source file (the CLI exits 2); pass `--no-clobber` when an existing output must not be replaced.
 
 ## For MCP hosts
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Reimagine This Page",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Content-Derived Design \u2014 reads the current HTML page and redesigns it from its own content. Palette, motifs, and motion derived from nouns, dates, and colors already in the source.",
   "permissions": [
     "activeTab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reimagine-it",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reimagine-it",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "license": "MIT",
       "bin": {
         "reimagine-it": "bin/reimagine-it.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "reimagine-it",
-  "version": "2.13.1",
-  "description": "Kayforkind Content-Derived Design CLI. HTML in, standalone HTML out from the sourceâ€™s own nouns, dates, numbers, and colors. Not the reimagineit.ai interview SaaS.",
+
+  "version": "2.14.0",
+  "description": "Kayforkind Content-Derived Design CLI. HTML in, standalone HTML out from the source\u00e2\u20ac\u2122s own nouns, dates, numbers, and colors. Not the reimagineit.ai interview SaaS.",
   "license": "MIT",
   "author": "Kayforkind",
   "repository": {

--- a/scripts/auto.js
+++ b/scripts/auto.js
@@ -11,6 +11,7 @@ const path = require('path');
 const { extractContent } = require('../src/extract');
 const { autoGenerate } = require('../src/auto');
 const { sourceFidelity } = require('../src/result');
+const { sameFileAsInput, assertWritable, writeFileAtomic } = require('../src/io');
 
 const MAX_INPUT_BYTES = 10 * 1024 * 1024;
 const args = parseArgs(process.argv.slice(2));
@@ -27,6 +28,8 @@ Options:
   --brief, -b <text>      Creative lens; it does not add source facts
   --candidates <n>        Evaluate 1–3 directions (default: 3); output includes all verified options
   --quiet, -q             Do not print the result summary
+  --no-clobber            Refuse (exit 2) instead of replacing an existing output file;
+                          the source path is always refused, flag or no flag
   --help, -h              Show this help
 `);
   process.exit(0);
@@ -63,18 +66,35 @@ const candidateDir = outputPath ? path.join(path.dirname(outputPath), path.basen
 const fidelity = sourceFidelity(content, result.output);
 
 if (outputPath) {
-  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, result.output, 'utf8');
-  result.candidates.slice(1).forEach((candidate, index) => {
-    fs.mkdirSync(candidateDir, { recursive: true });
-    fs.writeFileSync(path.join(candidateDir, `${String(index + 2).padStart(2, '0')}-${candidate.token}.html`), generateCandidate(content, candidate, args.brief), 'utf8');
-  });
+  const candidateFiles = result.candidates.slice(1).map((candidate, index) =>
+    path.join(candidateDir, `${String(index + 2).padStart(2, '0')}-${candidate.token}.html`)
+  );
+  try {
+    if (args.input && args.input !== '-' && sameFileAsInput(path.resolve(args.input), outputPath)) {
+      fail(`output would overwrite the source. Choose a different --output path: ${outputPath}`, 2);
+    }
+    assertWritable([outputPath, ...candidateFiles], args.noClobber);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileAtomic(outputPath, result.output, args.noClobber);
+    result.candidates.slice(1).forEach((candidate, index) => {
+      fs.mkdirSync(candidateDir, { recursive: true });
+      writeFileAtomic(candidateFiles[index], generateCandidate(content, candidate, args.brief), args.noClobber);
+    });
+  } catch (error) {
+    if (error.code === 'EEXIST') fail(`--no-clobber: ${error.message}`, 2);
+    throw error;
+  }
 } else {
   process.stdout.write(result.output);
 }
 
-fs.mkdirSync(path.dirname(reportPath), { recursive: true });
-fs.writeFileSync(reportPath, JSON.stringify({
+try {
+  if (args.input && args.input !== '-' && sameFileAsInput(path.resolve(args.input), reportPath)) {
+    fail(`report would overwrite the source. Choose a different --report path: ${reportPath}`, 2);
+  }
+  assertWritable([reportPath], args.noClobber);
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  writeFileAtomic(reportPath, JSON.stringify({
   mode: result.mode,
   token: result.token,
   seed: result.seed,
@@ -86,7 +106,11 @@ fs.writeFileSync(reportPath, JSON.stringify({
   source: inputLabel,
   artifact: outputPath || 'stdout',
   fidelity,
-}, null, 2) + '\n', 'utf8');
+}, null, 2) + '\n', args.noClobber);
+} catch (error) {
+  if (error.code === 'EEXIST') fail(`--no-clobber: ${error.message}`, 2);
+  throw error;
+}
 
 if (!args.quiet) {
   process.stderr.write(JSON.stringify({
@@ -122,6 +146,7 @@ function parseArgs(raw) {
     }
     if (arg === '--help' || arg === '-h') options.help = true;
     else if (arg === '--quiet' || arg === '-q') options.quiet = true;
+    else if (arg === '--no-clobber') options.noClobber = true;
     else return { error: `unknown option "${arg}". Use --help for usage.` };
   }
 

--- a/skills/reimagine-it/SKILL.md
+++ b/skills/reimagine-it/SKILL.md
@@ -98,6 +98,8 @@ npx reimagine-it extract -i page.html
 npx reimagine-it audit redesign.html
 ```
 
+The CLI enforces the source guard mechanically: an `--output` path that resolves to the source file exits 2 without writing. Pass `--no-clobber` to also refuse replacing an existing output file — useful when an agent or CI loop must not clobber a reviewed artifact.
+
 3. Open that artifact. Report from it. If `npx reimagine-it` cannot run, ship `REIMAGINED: partial` and name the exact blocker — do not substitute a model-written page.
 
 ## Categories (you choose · agent decides)

--- a/skills/reimagine-it/SKILL.md
+++ b/skills/reimagine-it/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   hosts:
     - claude-code
     - cursor

--- a/skills/reimagine-it/audit/SKILL.md
+++ b/skills/reimagine-it/audit/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/extract/SKILL.md
+++ b/skills/reimagine-it/extract/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/generate/SKILL.md
+++ b/skills/reimagine-it/generate/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/infographic/SKILL.md
+++ b/skills/reimagine-it/infographic/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/lock/SKILL.md
+++ b/skills/reimagine-it/lock/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/skills/reimagine-it/variations/SKILL.md
+++ b/skills/reimagine-it/variations/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: Kayforkind
-  version: "2.13.1"
+  version: "2.14.0"
   parent: reimagine-it
   hosts:
     - claude-code

--- a/src/io.js
+++ b/src/io.js
@@ -1,0 +1,93 @@
+/**
+ * Shared write helpers for reimagine-it.
+ *
+ * Two guarantees the CLI makes to agents and CI:
+ *   1. Outputs are never written to a path the source is read from — the
+ *      "source stays untouched" guarantee is enforced here, not just promised
+ *      in the skill docs.
+ *   2. Writes are atomic: content lands in a sibling temp file and is renamed
+ *      into place, so a concurrent reader or a crashed run never observes a
+ *      truncated artifact. Existing files are replaced, matching the
+ *      deterministic engine's byte-identical regeneration contract; callers
+ *      that need a refuse-if-exists policy pass `noClobber`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Refuse when the requested output path is the file the source was read from.
+ * Byte equality is not enough: the two paths may be spelled differently but
+ * resolve to the same file (relative vs absolute, .. segments, symlinks), so
+ * both are resolved and compared case-insensitively on Windows.
+ */
+function sameFileAsInput(inputPath, outputPath) {
+  if (!inputPath || inputPath === 'stdin.html' || !outputPath) return false;
+  try {
+    const inputStat = fs.statSync(inputPath);
+    const outputStat = fs.statSync(outputPath);
+    if (inputStat.dev === outputStat.dev && inputStat.ino === outputStat.ino) return true;
+    if (fs.realpathSync(inputPath) === fs.realpathSync(outputPath)) return true;
+  } catch (error) {
+    // Fall through to lexical comparison (e.g. output does not exist yet).
+  }
+  try {
+    const a = path.resolve(inputPath);
+    const b = path.resolve(outputPath);
+    return process.platform === 'win32'
+      ? a.toLowerCase() === b.toLowerCase()
+      : a === b;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Refuse, with `.code === 'EEXIST'`, if any target already exists. Callers
+ * collect every path a run would touch (artifact, reports, candidates) and
+ * pre-flight them so a `--no-clobber` refusal happens before anything is
+ * written — no partial output.
+ */
+function assertWritable(targets, noClobber) {
+  if (!noClobber) return;
+  for (const target of targets) {
+    if (target && fs.existsSync(target)) {
+      const error = new Error(`refusing to overwrite existing file: ${target}`);
+      error.code = 'EEXIST';
+      error.path = target;
+      throw error;
+    }
+  }
+}
+
+/**
+ * Write `data` to `filePath`, replacing any existing file. If `noClobber` is
+ * true, refuse instead of replacing an existing file: throws an Error with
+ * `.code === 'EEXIST'` so callers can report a clean, non-destructive refusal.
+ * The content is first written to a unique temp file in the destination
+ * directory and renamed over the target, so readers never see a partial file
+ * and a failed write leaves any previous artifact intact.
+ */
+function writeFileAtomic(filePath, data, noClobber) {
+  const resolved = path.resolve(filePath);
+  if (noClobber && fs.existsSync(resolved)) {
+    const error = new Error(`refusing to overwrite existing file: ${resolved}`);
+    error.code = 'EEXIST';
+    error.path = resolved;
+    throw error;
+  }
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  const tempPath = path.join(
+    path.dirname(resolved),
+    `.${path.basename(resolved)}.${process.pid}.${Date.now()}.tmp`
+  );
+  try {
+    fs.writeFileSync(tempPath, data, 'utf8');
+    fs.renameSync(tempPath, resolved);
+  } catch (error) {
+    try { fs.unlinkSync(tempPath); } catch (_) { /* best effort */ }
+    throw error;
+  }
+}
+
+module.exports = { sameFileAsInput, assertWritable, writeFileAtomic };

--- a/test/e2e/cli.e2e.test.js
+++ b/test/e2e/cli.e2e.test.js
@@ -348,6 +348,62 @@ test('mcp with a closed stdio exits promptly (never hangs)', function () {
   }
 });
 
+
+// ── output collisions: source guard, --no-clobber, atomic writes ───
+
+test('output overwrites an existing file by default (deterministic regeneration)', function () {
+  var run = cli(['-i', 'source.html', '-t', 'webpage', '-s', '5', '-o', 'out/collision.html', '-q']);
+  assert.strictEqual(run.code, 0, 'first write should exit 0, got ' + run.code + ': ' + run.stderr);
+  var before = fs.readFileSync(path.join(workDir, 'out', 'collision.html'), 'utf8');
+  run = cli(['-i', 'source.html', '-t', 'webpage', '-s', '5', '-o', 'out/collision.html', '-q']);
+  assert.strictEqual(run.code, 0, 'overwrite should exit 0, got ' + run.code + ': ' + run.stderr);
+  var after = fs.readFileSync(path.join(workDir, 'out', 'collision.html'), 'utf8');
+  assert.strictEqual(before, after, 'same seed should regenerate byte-identically over the old file');
+});
+
+test('--no-clobber refuses to replace an existing output and leaves it intact', function () {
+  var target = path.join(workDir, 'out', 'keepme.html');
+  var run = cli(['-i', 'source.html', '-t', 'webpage', '-s', '5', '-o', 'out/keepme.html', '-q']);
+  assert.strictEqual(run.code, 0, 'first write should exit 0');
+  var original = fs.readFileSync(target, 'utf8');
+  run = cli(['-i', 'source.html', '-t', 'landing', '-s', '6', '-o', 'out/keepme.html', '--no-clobber']);
+  assert.strictEqual(run.code, 2, 'should exit 2 on collision, got ' + run.code + ': ' + run.stdout);
+  assert.ok(run.stderr.indexOf('--no-clobber') >= 0, 'should name the refused flag: ' + run.stderr);
+  assert.strictEqual(fs.readFileSync(target, 'utf8'), original, 'existing file must be untouched');
+});
+
+test('--no-clobber writes normally when the output does not exist yet', function () {
+  var run = cli(['-i', 'source.html', '-t', 'webpage', '-s', '7', '-o', 'out/fresh.html', '--no-clobber', '-q']);
+  assert.strictEqual(run.code, 0, 'should exit 0, got ' + run.code + ': ' + run.stderr);
+  assert.ok(fs.existsSync(path.join(workDir, 'out', 'fresh.html')), 'should write the fresh artifact');
+});
+
+test('output path equal to the source path is refused, flag or no flag', function () {
+  var sourceBackup = fs.readFileSync(path.join(workDir, 'source.html'), 'utf8');
+  var run = cli(['-i', 'source.html', '-t', 'webpage', '-o', 'source.html']);
+  assert.strictEqual(run.code, 2, 'should exit 2, got ' + run.code + ': ' + run.stdout);
+  assert.ok(run.stderr.indexOf('would overwrite the source') >= 0, 'should name the source guard: ' + run.stderr);
+  run = cli(['-i', 'source.html', '-t', 'webpage', '-o', 'source.html', '--no-clobber']);
+  assert.strictEqual(run.code, 2, 'no-clobber must not weaken the source guard');
+  assert.strictEqual(fs.readFileSync(path.join(workDir, 'source.html'), 'utf8'), sourceBackup, 'source must be untouched');
+  run = cli(['-i', 'source.html', '-t', 'webpage', '-o', './out/../source.html']);
+  assert.strictEqual(run.code, 2, 'path spelling must not dodge the guard');
+});
+
+test('atomic writes leave no temp residue next to the artifact', function () {
+  var run = cli(['-i', 'source.html', '-t', 'infographic', '-s', '3', '-o', 'out/atomic.html', '--audit', '-q']);
+  assert.strictEqual(run.code, 0, 'should exit 0, got ' + run.code + ': ' + run.stderr);
+  var residue = fs.readdirSync(path.join(workDir, 'out')).filter(function (name) { return /\.tmp$/.test(name); });
+  assert.deepStrictEqual(residue, [], 'no .tmp files should survive a completed run');
+});
+
+test('failed --no-clobber run leaves no temp residue either', function () {
+  cli(['-i', 'source.html', '-t', 'webpage', '-s', '5', '-o', 'out/residue.html', '-q']);
+  var run = cli(['-i', 'source.html', '-t', 'webpage', '-s', '5', '-o', 'out/residue.html', '--no-clobber']);
+  assert.strictEqual(run.code, 2, 'should refuse the second write');
+  var residue = fs.readdirSync(path.join(workDir, 'out')).filter(function (name) { return /\.tmp$/.test(name); });
+  assert.deepStrictEqual(residue, [], 'a refused run must not leave temp files');
+});
 // ── cleanup ─────────────────────────────────────────────────────────
 
 try {


### PR DESCRIPTION
## Summary

Answers the reviewer question *"if `-o redesign.html` already exists, does reimagine-it refuse the write or replace it?"* — and closes the gap it exposed.

**As shipped (≤ v2.13.1):** `-o` over an existing file was a blind truncating `fs.writeFileSync` — exit 0 either way, no refusal path except OS errors. And the "source stays untouched" guarantee lived only in the skill docs; the CLI happily executed `-i page.html -o page.html`.

**This PR** keeps overwrite-by-default (the deterministic engine's byte-identical regeneration and CI's reproduction guard depend on it) and adds three non-breaking guarantees:

- **Mechanical source guard** — an `--output` path that resolves to the input file (same file via dev/ino + realpath, or resolved-path compare with Windows case-folding) exits 2 before anything is written. No flag lifts it. `-o -` and `--diff` are unaffected.
- **`--no-clobber`** — refuses (exit 2, `--no-clobber:` message) to replace any existing target: artifact, `--emit` reports, auto `*-options/` candidates, variations sheet + report, `npm run auto` report JSON. Pre-flighted via `assertWritable` so a refusal happens before any file is written — no partial output. Available on the default command, `lock`, `extract`, `variations`, and the auto runner.
- **Atomic writes everywhere** — new `src/io.js` `writeFileAtomic` (sibling temp file + rename) at every write site in `bin/reimagine-it.js` and `scripts/auto.js`: concurrent readers never observe a truncated artifact, and two parallel agents sharing an `-o` can no longer interleave partial HTML.

## Test plan

- 7 new e2e tests: overwrite-by-default regeneration, `--no-clobber` refusal (existing file byte-identical afterwards), fresh-file success, source-guard refusals including path-spelling dodges (`./out/../source.html`), zero `.tmp` residue on success and refusal — full e2e suite 34/34.
- Full 12-step battery: **ALL TESTS PASSED** (unit 68, MCP 20, fuzz 10, e2e 34, parity 3; stills, tarball 65 files, reproduction guard 17 artifacts byte-identical, site claims, version sync).
- Release prep included: version bumped to 2.14.0 across all sync-guard surfaces; `check-version-sync` reports `OK — one version everywhere: 2.14.0`.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>