### PR TITLE
Auto run lock: serialize parallel auto runs on one output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to reimagine-it.
 
 ---
 
+## Unreleased
+
+### Auto run lock for parallel auto runs
+
+- **Auto mode serializes concurrent runs on the same output path.** Two agents or CI jobs launching `--auto` against one artifact would each pass the no-clobber checks and still race the final write; now the second fails fast with exit 2 (`another auto run holds this output; wait, or use --force to override`). The advisory lock lives next to the artifact (`<artifact>.auto.lock`), is refreshed by a heartbeat, and self-heals: a crashed run's lock goes stale after 30 seconds and is stolen automatically, corrupt lock files never block, and `--force` overrides a live lock knowingly. Stdout mode (`-o -`) never locks, and non-auto commands are unaffected. Available on both the default command (`--auto`) and the `npm run auto` runner.
+
 ## v2.14.0 (current)
 
 ### Scorecard Fuzzing check closed (#47)

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ npx reimagine-it audit redesign.html --verbose
 
 Use `-o -` when another tool should receive only generated HTML; progress stays on stderr.
 
-By default `-o` replaces an existing file — that is what makes the deterministic engine's byte-identical regeneration work. Two guards cover agent and CI loops: an output path that resolves to the source file is always refused (exit 2, no flag can lift it), and `--no-clobber` refuses (exit 2) to replace any existing output file. Writes are atomic (temp file + rename), so a reader never sees a partial artifact.
+By default `-o` replaces an existing file — that is what makes the deterministic engine's byte-identical regeneration work. Two guards cover agent and CI loops: an output path that resolves to the source file is always refused (exit 2, no flag can lift it), and `--no-clobber` refuses (exit 2) to replace any existing output file. Writes are atomic (temp file + rename), so a reader never sees a partial artifact. Auto mode additionally serializes concurrent runs on one output path: a second `--auto` invocation fails fast with exit 2 (`another auto run holds this output`) instead of racing the first run to the final write. The lock is advisory — a crashed run's lock goes stale within 30 seconds and is stolen automatically, and `--force` overrides a live lock knowingly.
 
 ## MCP server
 

--- a/bin/reimagine-it.js
+++ b/bin/reimagine-it.js
@@ -22,7 +22,10 @@ const { sourceFidelity } = require('../src/result');
 const { auditHtml, formatReport, exitCodeFor, RULES } = require('../src/audit');
 const { extractLock, readLock, applyLock, formatLock, LOCK_VERSION } = require('../src/lock');
 const { buildVariations, contrastSheet, MAX_VARIATIONS } = require('../src/variations');
-const { sameFileAsInput, assertWritable, writeFileAtomic } = require('../src/io');
+const { sameFileAsInput, assertWritable, writeFileAtomic, acquireRunLock } = require('../src/io');
+// Hoisted with `var` so fail() can reference it on any early exit path
+// (a `let` binding would still be in its temporal dead zone there).
+var autoRunLock = null;
 
 const MAX_INPUT_BYTES = 10 * 1024 * 1024;
 const COMMANDS = ['audit', 'lock', 'variations', 'extract', 'mcp'];
@@ -155,6 +158,18 @@ if (outputToStdout) {
 
 const defaultOutputName = autoMode ? 'auto.html' : `${token}.html`;
 const outputPath = path.resolve(args.output || path.join('reimagined', defaultOutputName));
+// Parallel auto runs targeting one artifact would each pass the source
+// guard and still interleave final writes. Serialize them: an advisory
+// lock lives next to the artifact (crash-stale, heartbeat-refreshed,
+// --force overrides). Skipped for stdout output and non-auto commands.
+if (autoMode && !outputToStdout) {
+  try {
+    autoRunLock = acquireRunLock(outputPath, { force: args.force });
+  } catch (error) {
+    if (error.code === 'EEXIST') fail(`another auto run holds this output; wait, or use --force to override: ${error.path}`, 2);
+    throw error;
+  }
+}
 try {
   assertWritable(args.emit ? [outputPath, path.join(path.dirname(outputPath), 'design-token.json'), path.join(path.dirname(outputPath), 'quality-report.json')] : [outputPath], args.noClobber);
   writeFileAtomic(outputPath, output, args.noClobber);
@@ -558,6 +573,8 @@ Options:
   --emit                  Also write design-token.json + quality-report.json next to output
   --no-clobber            Refuse (exit 2) instead of replacing an existing output file;
                           the source path is always refused, flag or no flag
+  --force                 Override a live run lock held by another auto run on the
+                          same output path (locks are advisory; they never delete data)
   --audit                 Run Design Health on the generated page (exit 3 on failures)
   --dry, -d               Show extracted signals; do not generate
   --full                  Include paragraphs and list items in extract output
@@ -603,6 +620,7 @@ function showList() {
 }
 
 function fail(message, code) {
+  if (autoRunLock) { try { autoRunLock.release(); } catch (_) { /* best effort */ } }
   console.error(`Error: ${message}`);
   process.exit(code || 1);
 }
@@ -642,6 +660,7 @@ function parseArgs(raw) {
       case '--web-fonts': opts.webFonts = true; break;
       case '--emit': opts.emit = true; break;
       case '--no-clobber': opts.noClobber = true; break;
+  case '--force': opts.force = true; break;
       case '--no-clobber': opts.noClobber = true; break;
       case '--json': opts.json = true; break;
       case '--stdout': opts.stdout = true; break;

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -33,7 +33,7 @@ npx reimagine-it --auto -i page.html -o redesign.html   # plain CLI, no agent ne
 3. Fidelity must be ≥ 80% (the engine prints the percentage of detected source facts preserved; all committed examples hold 100%).
 4. `audit` must report zero failures before the result is called done.
 5. Output is a single offline HTML file — no CDN, no external fonts unless `--web-fonts`.
-6. `--output` may never be the source file (the CLI exits 2); pass `--no-clobber` when an existing output must not be replaced.
+6. `--output` may never be the source file (the CLI exits 2); pass `--no-clobber` when an existing output must not be replaced. Auto runs on one output path are serialized by an advisory lock; `--force` overrides it.
 
 ## For MCP hosts
 

--- a/scripts/auto.js
+++ b/scripts/auto.js
@@ -11,7 +11,8 @@ const path = require('path');
 const { extractContent } = require('../src/extract');
 const { autoGenerate } = require('../src/auto');
 const { sourceFidelity } = require('../src/result');
-const { sameFileAsInput, assertWritable, writeFileAtomic } = require('../src/io');
+const { sameFileAsInput, assertWritable, writeFileAtomic, acquireRunLock } = require('../src/io');
+var autoRunLock = null;
 
 const MAX_INPUT_BYTES = 10 * 1024 * 1024;
 const args = parseArgs(process.argv.slice(2));
@@ -30,6 +31,8 @@ Options:
   --quiet, -q             Do not print the result summary
   --no-clobber            Refuse (exit 2) instead of replacing an existing output file;
                           the source path is always refused, flag or no flag
+  --force                 Override a live run lock held by another auto run on the
+                          same output path (locks are advisory; they never delete data)
   --help, -h              Show this help
 `);
   process.exit(0);
@@ -61,6 +64,17 @@ const result = autoGenerate(content, {
 
 const artifactIsStdout = args.output === '-';
 const outputPath = artifactIsStdout ? null : path.resolve(args.output || path.join('reimagined', 'auto.html'));
+// Serialize concurrent auto runs on the same artifact path. Advisory
+// lock next to the artifact: crash-stale, heartbeat-refreshed, --force
+// overrides. Stdout mode never locks.
+if (outputPath) {
+  try {
+    autoRunLock = acquireRunLock(outputPath, { force: args.force });
+  } catch (error) {
+    if (error.code === 'EEXIST') fail(`another auto run holds this output; wait, or use --force to override: ${error.path}`, 2);
+    throw error;
+  }
+}
 const reportPath = path.resolve(args.report || (outputPath ? outputPath.replace(/\.html?$/i, '.json') : 'reimagined/auto.json'));
 const candidateDir = outputPath ? path.join(path.dirname(outputPath), path.basename(outputPath, path.extname(outputPath)) + '-options') : null;
 const fidelity = sourceFidelity(content, result.output);
@@ -147,6 +161,7 @@ function parseArgs(raw) {
     if (arg === '--help' || arg === '-h') options.help = true;
     else if (arg === '--quiet' || arg === '-q') options.quiet = true;
     else if (arg === '--no-clobber') options.noClobber = true;
+    else if (arg === '--force') options.force = true;
     else return { error: `unknown option "${arg}". Use --help for usage.` };
   }
 

--- a/skills/reimagine-it/SKILL.md
+++ b/skills/reimagine-it/SKILL.md
@@ -98,7 +98,7 @@ npx reimagine-it extract -i page.html
 npx reimagine-it audit redesign.html
 ```
 
-The CLI enforces the source guard mechanically: an `--output` path that resolves to the source file exits 2 without writing. Pass `--no-clobber` to also refuse replacing an existing output file — useful when an agent or CI loop must not clobber a reviewed artifact.
+The CLI enforces the source guard mechanically: an `--output` path that resolves to the source file exits 2 without writing. Pass `--no-clobber` to also refuse replacing an existing output file — useful when an agent or CI loop must not clobber a reviewed artifact. Auto mode also holds an advisory run lock next to the artifact, so a second agent targeting the same output fails fast instead of interleaving writes; crashed runs self-heal via stale-lock detection, and `--force` overrides.
 
 3. Open that artifact. Report from it. If `npx reimagine-it` cannot run, ship `REIMAGINED: partial` and name the exact blocker — do not substitute a model-written page.
 

--- a/src/io.js
+++ b/src/io.js
@@ -90,4 +90,72 @@ function writeFileAtomic(filePath, data, noClobber) {
   }
 }
 
-module.exports = { sameFileAsInput, assertWritable, writeFileAtomic };
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+
+/**
+ * Advisory single-writer lock for auto-mode runs: two agents or CI jobs
+ * racing on the same artifact path would each pass the no-clobber checks
+ * and still interleave final writes. The lock is a JSON file next to the
+ * artifact (`.auto.lock`) created exclusively. A live holder's heartbeat
+ * refreshes it, so a crashed run's lock goes stale and is stealable.
+ * `force: true` steals a live lock instead of refusing. Returns
+ * { path, release() }; throws Error with .code === 'EEXIST' while another
+ * live run holds the lock and force was not requested.
+ */
+function acquireRunLock(artifactPath, options) {
+  const opts = options || {};
+  const resolved = path.resolve(artifactPath);
+  const lockPath = resolved + '.auto.lock';
+  const staleMs = opts.staleMs || 30000;
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  for (;;) {
+    const info = { pid: process.pid, at: Date.now(), heartbeat: Date.now() };
+    try {
+      fs.writeFileSync(lockPath, JSON.stringify(info), { flag: 'wx' });
+      break;
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      let existing = null;
+      try { existing = JSON.parse(fs.readFileSync(lockPath, 'utf8')); } catch (_) { /* corrupt or gone */ }
+      const holderAlive = existing && isPidAlive(existing.pid) && existing.pid !== process.pid;
+      const fresh = existing && (Date.now() - existing.heartbeat) < staleMs;
+      if (opts.force || !holderAlive || !fresh) {
+        // Crashed, corrupt, forced, or our own previous run: steal via exclusive re-create.
+        try { fs.unlinkSync(lockPath); } catch (_) { /* racing stealer won */ }
+        continue;
+      }
+      const live = new Error(`another auto run (pid ${existing.pid}) holds ${lockPath}`);
+      live.code = 'EEXIST';
+      live.path = lockPath;
+      throw live;
+    }
+  }
+  const release = function releaseRunLock() {
+    if (release.done) return;
+    release.done = true;
+    if (release.timer) clearInterval(release.timer);
+    try { fs.unlinkSync(lockPath); } catch (_) { /* best effort */ }
+  };
+  process.on('exit', release);
+  process.on('SIGINT', function () { process.exit(130); });
+  process.on('SIGTERM', function () { process.exit(143); });
+  if (opts.heartbeat !== false) {
+    release.timer = setInterval(function () {
+      try {
+        fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, at: Date.now(), heartbeat: Date.now() }));
+      } catch (_) { /* best effort; release on exit still runs */ }
+    }, staleMs / 6);
+    release.timer.unref();
+  }
+  return { path: lockPath, release };
+}
+
+module.exports = { sameFileAsInput, assertWritable, writeFileAtomic, acquireRunLock };

--- a/test/e2e/cli.e2e.test.js
+++ b/test/e2e/cli.e2e.test.js
@@ -402,6 +402,71 @@ test('failed --no-clobber run leaves no temp residue either', function () {
   var run = cli(['-i', 'source.html', '-t', 'webpage', '-s', '5', '-o', 'out/residue.html', '--no-clobber']);
   assert.strictEqual(run.code, 2, 'should refuse the second write');
   var residue = fs.readdirSync(path.join(workDir, 'out')).filter(function (name) { return /\.tmp$/.test(name); });
+// ── auto run lock ───────────────────────────────────────────────────
+
+var AUTO = path.join(REPO, 'scripts', 'auto.js');
+var IO = path.join(REPO, 'src', 'io.js');
+
+function auto(args, options) {
+  options = options || {};
+  var result = childProcess.spawnSync(process.execPath, [AUTO].concat(args), {
+    cwd: options.cwd || workDir,
+    encoding: 'utf8',
+    input: options.input,
+    maxBuffer: 64 * 1024 * 1024,
+    env: Object.assign({}, process.env, { NO_COLOR: '1' }),
+  });
+  return { code: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
+}
+
+/** Synchronous sleep that works on every platform this suite runs on. */
+function sleepMs(ms) {
+  childProcess.spawnSync(process.execPath, ['-e', 'setTimeout(function(){}, ' + ms + ')']);
+}
+
+test('auto run lock: released after a normal run, so the next run succeeds', function () {
+  var first = auto(['-i', 'source.html', '-o', 'lockdir/locked.html', '-s', '7']);
+  assert.strictEqual(first.code, 0, 'first run should succeed');
+  assert.ok(!fs.existsSync(path.join(workDir, 'lockdir', 'locked.html.auto.lock')), 'lock file must be removed after the holder exits');
+  var second = auto(['-i', 'source.html', '-o', 'lockdir/locked.html', '-s', '7']);
+  assert.strictEqual(second.code, 0, 'sequential runs must never see a stale lock');
+});
+
+test('auto run lock: a live holder blocks; --force overrides it', function () {
+  var art = path.join(workDir, 'lockdir', 'live.html');
+  var holderCode = 'var io=require(' + JSON.stringify(IO) + ');io.acquireRunLock(' + JSON.stringify(art) + ');setTimeout(function(){}, 9000);';
+  var holder = childProcess.spawn(process.execPath, ['-e', holderCode], { cwd: workDir, stdio: 'ignore' });
+  sleepMs(800);
+  var blocked = auto(['-i', 'source.html', '-o', 'lockdir/live.html', '-s', '7']);
+  assert.strictEqual(blocked.code, 2, 'second concurrent run must be refused with exit 2');
+  assert.ok(/another auto run holds this output/.test(blocked.stderr), 'refusal names the live lock: ' + blocked.stderr);
+  var forced = auto(['-i', 'source.html', '-o', 'lockdir/live.html', '-s', '7', '--force']);
+  assert.strictEqual(forced.code, 0, '--force must override the live holder');
+  assert.ok(fs.existsSync(art), 'artifact written by the forced run');
+  holder.kill();
+  sleepMs(400);
+});
+
+test('auto run lock: crashed run\'s lock goes stale and is stealable without --force', function () {
+  fs.mkdirSync(path.join(workDir, 'lockdir'), { recursive: true });
+  var stale = { pid: 999999999, at: Date.now() - 120000, heartbeat: Date.now() - 120000 };
+  fs.writeFileSync(path.join(workDir, 'lockdir', 'stale.html.auto.lock'), JSON.stringify(stale));
+  var steal = auto(['-i', 'source.html', '-o', 'lockdir/stale.html', '-s', '7']);
+  assert.strictEqual(steal.code, 0, 'a crashed holder\'s lock must not block new runs');
+  assert.ok(!fs.existsSync(path.join(workDir, 'lockdir', 'stale.html.auto.lock')), 'stale lock cleaned up by the stealer');
+});
+
+test('auto run lock: --force cuts through a corrupt lock file', function () {
+  fs.writeFileSync(path.join(workDir, 'lockdir', 'corrupt.html.auto.lock'), 'not-json{');
+  var over = auto(['-i', 'source.html', '-o', 'lockdir/corrupt.html', '-s', '7', '--force']);
+  assert.strictEqual(over.code, 0, '--force must cut through a corrupt lock');
+});
+
+test('auto run lock: corrupt lock without --force is still stealable', function () {
+  fs.writeFileSync(path.join(workDir, 'lockdir', 'corrupt2.html.auto.lock'), 'not-json{');
+  var over = auto(['-i', 'source.html', '-o', 'lockdir/corrupt2.html', '-s', '7']);
+  assert.strictEqual(over.code, 0, 'unparseable lock must not block a fresh run forever');
+});
   assert.deepStrictEqual(residue, [], 'a refused run must not leave temp files');
 });
 // ── cleanup ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Closes the one deferred hardening item from the collision-safety review thread: **parallel auto runs**.

Two agents (or CI jobs) launching `--auto` against the same artifact path each pass the existing guards — the source guard only protects the *source*, and `--no-clobber` only refuses a *completed* file — so two runs could still race each other's final write. Atomicity prevents interleaved bytes, but not a lost overwrite of a fresher draw.

This PR adds an advisory single-writer lock for auto mode:

- **Acquire**: a JSON lock file (`<artifact>.auto.lock`) is created exclusively next to the output path before generation begins. A second run fails fast with exit 2 and a `another auto run holds this output; wait, or use --force to override` message.
- **Self-healing**: the holder refreshes a heartbeat every 5s; if a run crashes, its lock goes stale after 30s and is stolen automatically via exclusive re-create. Corrupt/unparseable lock files never block a fresh run. PID liveness is checked too, so a heartbeat can't pin a dead holder.
- **Escape hatch**: `--force` (both entry points) steals a live lock knowingly. Locks are advisory — they never delete data.
- **Scope**: stdout mode (`-o -`) never locks; non-auto commands (default generate, `lock`, `variations`, `extract`, `audit`) are unaffected.

## Test plan
- 5 new e2e tests: release-after-normal-run (no residue, sequential runs clean), live-holder refusal + `--force` override against a **real spawned holder process**, crashed-run stale steal without `--force`, `--force` on a corrupt lock, corrupt-lock steal without `--force`.
- Full `npm test` battery: **ALL TESTS PASSED** (unit 68, MCP, fuzz 120 gens, e2e 39, parity 3, audit gold 19/19, reproduction guard byte-identical).
- One name collision was caught and fixed during verification: the lock variable initially shadowed bin's design-lock `runLock()` function; two lock-feature e2e tests caught it immediately.