### PR TITLE
chore(deps): unify action bumps — codeql-action v4.38.0, upload-artifact v7.0.1, gh-release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # codeql-action is grouped alone: its init/analyze/upload-sarif steps
+    # must share one version — a lone-bump PR fails Analyze on version skew.
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action/*"
     labels:
       - dependencies

--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -124,7 +124,7 @@ jobs:
       # for non-release jobs. The docs copy is refreshed by the owner by
       # unzipping the released boards.
       - name: Upload token boards as workflow artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: token-boards
           path: |
@@ -221,7 +221,7 @@ jobs:
           subject-path: ${{ env.TARBALL }}
 
       - name: Attach artifacts + provenance to the release
-        uses: softprops/action-gh-release@e598afbe1493e6b1bafb1f389cabb956eab91231 # v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -28,11 +28,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           languages: javascript
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           category: "/language:javascript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Supersedes #70 #71 #72 #73 #74.

## Why one PR instead of five

`github/codeql-action` steps must run the same version. Dependabot filed the init, analyze, and upload-sarif bumps as three separate PRs (#72, #74, #70) — each one alone left `sast.yml` mixed-version, so the `Analyze (javascript)` job failed with *"Not all workflow steps that use github/codeql-action use the same version"* on both failing PRs. Neither could merge first: a deadlock.

## What this does

- **codeql-action v4.37.9 → v4.38.0** (`b96794f0`) across all three refs: `init` + `analyze` (sast.yml) and `upload-sarif` (scorecard.yml) — moved in lockstep
- **upload-artifact v4.6.2 → v7.0.1** in release-benchmark.yml (#71) — the last straggler; scorecard.yml and stress.yml already run this exact v7 SHA in production, green
- **softprops/action-gh-release** maintenance bump (#73, `efb3536`)
- **dependabot.yml**: `github-actions` ecosystem gains groups — `codeql-actions` (its own group; version-coupled steps must bump together) and `github-actions` (everything else) — so future coupled bumps arrive as one batched PR instead of deadlocking

## Verification

- YAML parse OK on all 4 touched files
- Full battery: ALL TESTS PASSED
- SAST runs on PRs, so this PR's CI exercises codeql-action v4.38.0 for real
- upload-artifact v7 behavior already proven in production by scorecard/stress runs